### PR TITLE
invalid value should set empty text in input

### DIFF
--- a/src/InputNumber.js
+++ b/src/InputNumber.js
@@ -99,6 +99,8 @@ var InputNumber = React.createClass({
         }
       }
       this.setValue(val);
+    } else {
+      this.setValue('');
     }
   },
 


### PR DESCRIPTION
现在对于没有 defaultValue 的输入框，一开始输入非数字字符，可以键入。

对于非法数字字符，应始终置空。