### PR TITLE
fix: should work with React@0.15.0

### DIFF
--- a/src/InputNumber.js
+++ b/src/InputNumber.js
@@ -216,7 +216,11 @@ const InputNumber = React.createClass({
   },
 
   render() {
-    const props = this.props;
+    const props = {...this.props};
+    // Remove React warning.
+    // Warning: Input elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both).
+    delete props.defaultValue;
+
     const prefixCls = props.prefixCls;
     const classes = classNames({
       [prefixCls]: true,


### PR DESCRIPTION
Fix.

```bash
warning.js:44Warning: Input elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). 
Decide between using a controlled or uncontrolled input element and remove one of these props. More info: https://fb.me/react-controlled-components
```