### PR TITLE
Fixed crash on Android on textInput blur. Added optional prop keyboardType.

### DIFF
--- a/examples/react-native/demo.js
+++ b/examples/react-native/demo.js
@@ -1,11 +1,12 @@
 /* eslint no-console:0 */
 import React, { Component } from 'react';
 import {
+  Platform,
   StyleSheet,
   Text,
-  View,
   TextInput,
   TouchableOpacity,
+  View,
 } from 'react-native';
 
 import InputNumber from '../../src/';
@@ -76,6 +77,7 @@ class InputNumberDemo extends Component {
             readOnly={this.state.readOnly}
             onChange={this.onChange}
             disabled={this.state.disabled}
+            keyboardType={Platform.OS === 'ios' ? 'number-pad' : 'numeric'}
           />
         </View>
         <View style={styles.buttons}>

--- a/src/index.ios.js
+++ b/src/index.ios.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { View, TextInput, Text, TouchableWithoutFeedback } from 'react-native';
+import { Text, TextInput, TouchableWithoutFeedback, View } from 'react-native';
 import mixin from './mixin';
 
 const InputNumber = React.createClass({
@@ -20,6 +20,7 @@ const InputNumber = React.createClass({
     value: PropTypes.number,
     defaultValue: PropTypes.number,
     readOnly: PropTypes.bool,
+    keyboardType: PropTypes.string,
   },
 
   mixins: [mixin],
@@ -141,9 +142,10 @@ const InputNumber = React.createClass({
           autoFocus={props.autoFocus}
           editable={editable}
           onFocus={this.onFocus}
-          onBlur={this.onBlur}
+          onEndEditing={this.onBlur}
           onChange={this.onChange}
           underlineColorAndroid="transparent"
+          keyboardType={props.keyboardType}
         />
         <TouchableWithoutFeedback
           onPressIn={(editable && !upDisabledStyle) ? this.onPressInUp : undefined}


### PR DESCRIPTION
Added new optional prop keyboardType. Changed onBlur to onEndEditing for Android support. The onBlur event object on Android doesn't contain the expected text property, onEndEditing's event object does.