### PR TITLE
support of ctrl and shift key & simple formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,19 @@ react-native run-ios
           <td></td>
           <td>custom the down step element</td>
         </tr>
+        <tr>
+          <td>formatter</td>
+          <td>Function</td>
+          <td></td>
+          <td>Specifies the format of the value presented</td>
+        </tr>
     </tbody>
 </table>
+
+## Keyboard Navigation
+* When you hit the <kbd>⬆</kbd> or <kbd>⬇</kbd> key, the input value will be increased or decreased by `step`
+* With the <kbd>Shift</kbd> key (<kbd>Shift+⬆</kbd>, <kbd>Shift+⬇</kbd>), the input value will be changed by `10 * step`
+* With the <kbd>Ctrl</kbd> or <kbd>⌘</kbd> key (<kbd>Ctrl+⬆</kbd> or <kbd>⌘+⬆</kbd> or <kbd>Ctrl+⬇</kbd> or <kbd>⌘+⬇</kbd> ), the input value will be changed by `0.1 * step`
 
 ## Test Case
 

--- a/examples/combination-key-format.html
+++ b/examples/combination-key-format.html
@@ -1,0 +1,1 @@
+placeholder

--- a/examples/combination-key-format.js
+++ b/examples/combination-key-format.js
@@ -1,0 +1,56 @@
+/* eslint no-console:0 */
+require('rc-input-number/assets/index.less');
+const InputNumber = require('rc-input-number');
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+const Component = React.createClass({
+  getInitialState() {
+    return {
+      disabled: false,
+      readOnly: false,
+      value: 5,
+    };
+  },
+  onChange(value) {
+    console.log('onChange:', value);
+    this.setState({ value });
+  },
+  toggleDisabled() {
+    this.setState({
+      disabled: !this.state.disabled,
+    });
+  },
+  toggleReadOnly() {
+    this.setState({
+      readOnly: !this.state.readOnly,
+    });
+  },
+  format(num) {
+    return `$ ${num}`;
+  },
+  render() {
+    return (
+      <div style={{ margin: 10 }}>
+        <InputNumber
+          min={-8000}
+          max={10000}
+          value={this.state.value}
+          style={{ width: 100 }}
+          readOnly={this.state.readOnly}
+          onChange={this.onChange}
+          disabled={this.state.disabled}
+          autoFocus={false}
+          step={0.5}
+          formatter={this.format}
+        />
+        <p>
+          <button onClick={this.toggleDisabled}>toggle Disabled</button>
+          <button onClick={this.toggleReadOnly}>toggle readOnly</button>
+        </p>
+      </div>
+    );
+  },
+});
+
+ReactDOM.render(<Component/>, document.getElementById('__react-content'));

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ const InputNumber = React.createClass({
     upHandler: PropTypes.node,
     downHandler: PropTypes.node,
     useTouch: PropTypes.bool,
+    formatter: PropTypes.func,
   },
 
   mixins: [mixin],
@@ -56,9 +57,13 @@ const InputNumber = React.createClass({
 
   onKeyDown(e, ...args) {
     if (e.keyCode === 38) {
-      this.up(e);
+      const ratio = this.getRatio(e);
+      this.up(e, ratio);
+      this.stop();
     } else if (e.keyCode === 40) {
-      this.down(e);
+      const ratio = this.getRatio(e);
+      this.down(e, ratio);
+      this.stop();
     }
     const { onKeyDown } = this.props;
     if (onKeyDown) {
@@ -74,12 +79,29 @@ const InputNumber = React.createClass({
     }
   },
 
+  getRatio(e) {
+    let ratio = 1;
+    if (e.metaKey || e.ctrlKey) {
+      ratio = 0.1;
+    } else if (e.shiftKey) {
+      ratio = 10;
+    }
+    return ratio;
+  },
+
   getValueFromEvent(e) {
     return e.target.value;
   },
 
   focus() {
     this.refs.input.focus();
+  },
+
+  formatWrapper(num) {
+    if (this.props.formatter) {
+      return this.props.formatter(num);
+    }
+    return num;
   },
 
   render() {
@@ -145,6 +167,7 @@ const InputNumber = React.createClass({
         onMouseLeave: this.stop,
       };
     }
+    const inputDisplayValueFormat = this.formatWrapper(inputDisplayValue);
 
     // ref for test
     return (
@@ -188,8 +211,8 @@ const InputNumber = React.createClass({
             autoComplete="off"
             onFocus={this.onFocus}
             onBlur={this.onBlur}
-            onKeyDown={this.onKeyDown}
-            onKeyUp={this.onKeyUp}
+            onKeyDown={editable ? this.onKeyDown : noop}
+            onKeyUp={editable ? this.onKeyUp : noop}
             autoFocus={props.autoFocus}
             readOnly={props.readOnly}
             disabled={props.disabled}
@@ -198,7 +221,7 @@ const InputNumber = React.createClass({
             name={props.name}
             onChange={this.onChange}
             ref="input"
-            value={inputDisplayValue}
+            value={inputDisplayValueFormat}
           />
         </div>
       </div>

--- a/tests/index.js
+++ b/tests/index.js
@@ -89,6 +89,28 @@ describe('inputNumber', () => {
       });
       expect(inputNumber.state.value).to.be(97);
     });
+
+    it('combination keys works', () => {
+      Simulate.keyDown(inputElement, {
+        keyCode: keyCode.DOWN, shiftKey: true,
+      });
+      expect(inputNumber.state.value).to.be(88);
+
+      Simulate.keyDown(inputElement, {
+        keyCode: keyCode.UP, ctrlKey: true,
+      });
+      expect(inputNumber.state.value).to.be(88.1);
+
+      Simulate.keyDown(inputElement, {
+        keyCode: keyCode.UP, shiftKey: true,
+      });
+      expect(inputNumber.state.value).to.be(98.1);
+
+      Simulate.keyDown(inputElement, {
+        keyCode: keyCode.DOWN, ctrlKey: true,
+      });
+      expect(inputNumber.state.value).to.be(98);
+    });
   });
 
   describe('clickable', () => {
@@ -201,6 +223,17 @@ describe('inputNumber', () => {
       Simulate.blur(inputElement);
       expect(inputNumber.state.value).to.be(1);
       expect(inputElement.value).to.be('1');
+    });
+  });
+
+  describe('check value changes with readonly props set to true', () => {
+    it('no value changes after readonly works', () => {
+      example.triggerBoolean('readOnly');
+      Simulate.focus(inputElement);
+      Simulate.keyDown(inputElement, { keyCode: keyCode.UP });
+      expect(inputNumber.state.value).to.be(98);
+      Simulate.keyDown(inputElement, { keyCode: keyCode.DOWN });
+      expect(inputNumber.state.value).to.be(98);
     });
   });
 
@@ -577,6 +610,134 @@ describe('inputNumber', () => {
       Simulate.focus(inputElement);
       Simulate.blur(inputElement);
       expect(onChangeCallCount).to.be(3);
+    });
+  });
+
+  describe('formatter', () => {
+    it('formatter on default', () => {
+      const Demo = React.createClass({
+        render() {
+          return (<InputNum
+            ref="inputNum"
+            step={1}
+            value={5}
+            formatter={num => `$ ${num}`}
+          />);
+        },
+      });
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.refs.input);
+
+      expect(inputNumber.state.value).to.be(5);
+      expect(inputElement.value).to.be('$ 5');
+    });
+
+    it('formatter on mousedown', () => {
+      const Demo = React.createClass({
+        render() {
+          return (<InputNum
+            ref="inputNum"
+            step={1}
+            defaultValue={5}
+            formatter={num => `$ ${num}`}
+          />);
+        },
+      });
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.refs.input);
+
+      Simulate.mouseDown(ReactDOM.findDOMNode(inputNumber.refs.up));
+      expect(inputNumber.state.value).to.be(6);
+      expect(inputElement.value).to.be('$ 6');
+      Simulate.mouseDown(ReactDOM.findDOMNode(inputNumber.refs.down));
+      expect(inputNumber.state.value).to.be(5);
+      expect(inputElement.value).to.be('$ 5');
+    });
+
+    it('formatter on touchstart', () => {
+      const Demo = React.createClass({
+        render() {
+          return (<InputNum
+            ref="inputNum"
+            step={1}
+            defaultValue={5}
+            useTouch
+            formatter={num => `${num} ¥`}
+          />);
+        },
+      });
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.refs.input);
+
+      Simulate.touchStart(ReactDOM.findDOMNode(inputNumber.refs.up));
+      expect(inputNumber.state.value).to.be(6);
+      expect(inputElement.value).to.be('6 ¥');
+      Simulate.touchStart(ReactDOM.findDOMNode(inputNumber.refs.down));
+      expect(inputNumber.state.value).to.be(5);
+      expect(inputElement.value).to.be('5 ¥');
+    });
+
+    it('formatter on keydown', () => {
+      const Demo = React.createClass({
+        render() {
+          return (<InputNum
+            ref="inputNum"
+            step={1}
+            defaultValue={5}
+            formatter={num => `$ ${num} ¥`}
+          />);
+        },
+      });
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.refs.input);
+
+      Simulate.focus(inputElement);
+      Simulate.keyDown(inputElement, { keyCode: keyCode.UP });
+      expect(inputNumber.state.value).to.be(6);
+      expect(inputElement.value).to.be('$ 6 ¥');
+      Simulate.keyDown(inputElement, { keyCode: keyCode.DOWN });
+      expect(inputNumber.state.value).to.be(5);
+      expect(inputElement.value).to.be('$ 5 ¥');
+    });
+
+    it('formatter on direct input', () => {
+      let onChangeFirstArgumentFormat;
+      let onChangeCallCountFormat = 0;
+
+      const Demo = React.createClass({
+        getInitialState() {
+          return { value: 5 };
+        },
+        onChange(value) {
+          onChangeFirstArgumentFormat = value;
+          onChangeCallCountFormat += 1;
+          this.setState({ value });
+        },
+        render() {
+          return (<InputNum
+            ref="inputNum"
+            step={1}
+            defaultValue={5}
+            formatter={num => `$ ${num}`}
+            onChange={this.onChange}
+          />);
+        },
+      });
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.refs.input);
+
+      Simulate.focus(inputElement);
+      Simulate.change(inputElement, { target: { value: '100' } });
+      expect(inputElement.value).to.be('$ 100');
+      expect(onChangeFirstArgumentFormat).to.be(100);
+      Simulate.blur(inputElement);
+      expect(inputElement.value).to.be('$ 100');
+      expect(inputNumber.state.value).to.be(100);
     });
   });
 });


### PR DESCRIPTION
1、support of ctrl and shift key which could +10, +0.1 times of step          
2、simple formatter, with the function eg:          
```
format (num) {
  return "$ "+ num
}
```
3、bug fix, the value still changes when pressing up or down key even with the readonly status

Thanks, Sincerely
Jiramew