### PR TITLE
UX improvements when formatter exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,11 +48,21 @@ const InputNumber = React.createClass({
     this.componentDidUpdate();
   },
 
+  componentWillUpdate() {
+    this.start = this.refs.input.selectionStart;
+    this.end = this.refs.input.selectionEnd;
+  },
+
   componentDidUpdate() {
     if (this.props.focusOnUpDown &&
       this.state.focused &&
       document.activeElement !== this.refs.input) {
       this.focus();
+    }
+
+    const selectionRange = this.refs.input.setSelectionRange;
+    if (selectionRange && typeof selectionRange === 'function') {
+      this.refs.input.setSelectionRange(this.start, this.end);
     }
   },
 

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -2,7 +2,7 @@ function noop() {
 }
 
 function defaultParser(input) {
-  return input.replace(/[^\w\.-]*/g, '');
+  return input.replace(/[^\w\.-]+/g, '');
 }
 
 /**


### PR DESCRIPTION
There was an issue at https://github.com/ant-design/ant-design/issues/5303.

The problem is as follows

- When testing on http://regexr.com, the regex expression at https://github.com/react-component/input-number/blob/master/src/mixin.js#L5 did not work as expected.

- The number could not be deleted if the formatter is exist.