### PR TITLE
fix issue: #72

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -172,7 +172,7 @@ export default {
       return num;
     }
     const precision = Math.abs(this.getMaxPrecision(num));
-    if (precision) {
+    if (precision || precision === 0) {
       return Number(num).toFixed(precision);
     }
     return num.toString();


### PR DESCRIPTION
修改 mixin.js 第175行的判断，使 this.props.precision 传入值为 0 的时候也能生效。