### PR TITLE
feat: add support of tabIndex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const InputNumber = createReactClass({
     onKeyDown: PropTypes.func,
     onKeyUp: PropTypes.func,
     prefixCls: PropTypes.string,
+    tabIndex: PropTypes.string,
     disabled: PropTypes.bool,
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,
@@ -48,6 +49,7 @@ const InputNumber = createReactClass({
       focusOnUpDown: true,
       useTouch: false,
       prefixCls: 'rc-input-number',
+      tabIndex:'0'
     };
   },
 
@@ -256,6 +258,7 @@ const InputNumber = createReactClass({
             placeholder={props.placeholder}
             onClick={props.onClick}
             className={`${prefixCls}-input`}
+            tabIndex={props.tabIndex}
             autoComplete="off"
             onFocus={this.onFocus}
             onBlur={this.onBlur}

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const InputNumber = createReactClass({
       focusOnUpDown: true,
       useTouch: false,
       prefixCls: 'rc-input-number',
-      tabIndex:'0'
+      tabIndex: '0',
     };
   },
 


### PR DESCRIPTION
add props support of tabIndex , and the default props of tabIndex are the '0'，tabindex="0" means that the element should be focusable in sequential keyboard navigation, but its order is defined by the document's source order.

