### PR TITLE
fix stop interval when reach max/min

### DIFF
--- a/src/index.ios.js
+++ b/src/index.ios.js
@@ -19,7 +19,10 @@ const InputNumber = createReactClass({
     autoFocus: PropTypes.bool,
     disabled: PropTypes.bool,
     step: PropTypes.number,
-    value: PropTypes.number,
+    value: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string // can be string
+    ]),
     defaultValue: PropTypes.number,
     readOnly: PropTypes.bool,
     keyboardType: PropTypes.string,

--- a/src/index.ios.js
+++ b/src/index.ios.js
@@ -21,7 +21,7 @@ const InputNumber = createReactClass({
     step: PropTypes.number,
     value: PropTypes.oneOfType([
       PropTypes.number,
-      PropTypes.string // can be string
+      PropTypes.string, // can be string
     ]),
     defaultValue: PropTypes.number,
     readOnly: PropTypes.bool,

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -272,6 +272,13 @@ export default {
       e.persist();
     }
     this.stop();
+
+    // stop interval when reach min
+    const value = this.getCurrentValidValue(this.state.inputValue);
+    if(Number(this.props.min) === Number(value) ){
+      return
+    }
+
     this.step('down', e, ratio);
     this.autoStepTimer = setTimeout(() => {
       this.down(e, ratio, true);
@@ -283,6 +290,13 @@ export default {
       e.persist();
     }
     this.stop();
+
+    // stop interval when reach max
+    const value = this.getCurrentValidValue(this.state.inputValue);
+    if(Number(this.props.max) === Number(value) ){
+      return
+    }
+
     this.step('up', e, ratio);
     this.autoStepTimer = setTimeout(() => {
       this.up(e, ratio, true);

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -275,8 +275,8 @@ export default {
 
     // stop interval when reach min
     const value = this.getCurrentValidValue(this.state.inputValue);
-    if(Number(this.props.min) === Number(value) ){
-      return
+    if (Number(this.props.min) === Number(value)) {
+      return;
     }
 
     this.step('down', e, ratio);
@@ -293,8 +293,8 @@ export default {
 
     // stop interval when reach max
     const value = this.getCurrentValidValue(this.state.inputValue);
-    if(Number(this.props.max) === Number(value) ){
-      return
+    if (Number(this.props.max) === Number(value)) {
+      return;
     }
 
     this.step('up', e, ratio);


### PR DESCRIPTION
when value reach min, inner interval couldn't stop, then I input some value, it will decrease to min value gradually


![2017-08-21 13 37 02](https://user-images.githubusercontent.com/14126445/29505076-6c4a1828-8676-11e7-9e80-3504c8a76fc3.gif)


so I add code to stop interval when reach min and max 

mixin.js
```js
up(e, ratio, recursive) {
    if (e.persist) {
      e.persist();
    }
    this.stop();

    // stop interval when reach max
    const value = this.getCurrentValidValue(this.state.inputValue);
    if(Number(this.props.max) === Number(value) ){
      return
    }

    this.step('up', e, ratio);
    this.autoStepTimer = setTimeout(() => {
      this.up(e, ratio, true);
    }, recursive ? SPEED : DELAY);
  },
```
