### PR TITLE
Fix getValidValue function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -226,7 +226,6 @@ export default class InputNumber extends React.Component {
 
   getValidValue(value, min = this.props.min, max = this.props.max) {
     let val = parseFloat(value, 10);
-    
     // https://github.com/ant-design/ant-design/issues/7358
     if (isNaN(val)) {
       return value;

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ export default class InputNumber extends React.Component {
   componentWillReceiveProps(nextProps) {
     if ('value' in nextProps) {
       const value = this.state.focused
-        ? nextProps.value : this.getValidValue(nextProps.value);
+        ? nextProps.value : this.getValidValue(nextProps.value, nextProps.min, nextProps.max);
       this.setState({
         value,
         inputValue: this.inputting ? value : this.toPrecisionAsStep(value),
@@ -224,17 +224,18 @@ export default class InputNumber extends React.Component {
     return e.target.value;
   }
 
-  getValidValue(value) {
+  getValidValue(value, min = this.props.min, max = this.props.max) {
     let val = parseFloat(value, 10);
+    
     // https://github.com/ant-design/ant-design/issues/7358
     if (isNaN(val)) {
       return value;
     }
-    if (val < this.props.min) {
-      val = this.props.min;
+    if (val < min) {
+      val = min;
     }
-    if (val > this.props.max) {
-      val = this.props.max;
+    if (val > max) {
+      val = max;
     }
     return val;
   }


### PR DESCRIPTION
### Problem
Previously, `getValidValue(value)` compared `value` to the current prop's `min` and `max`. However, it is called in 'componentWillReceiveProps', so `getValidValue(value)` compared nextProp's `value` to current prop's `min` and `max`. This is incorrect -- it should compare nextProp's `value` to nextProp's `min` and `max`.

### Solution
Add `min` and `max` parameters  to getValidValue() function, with default values of `this.props.min` and `this.props.max`