### PR TITLE
fixed down and up function infinite recursion

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -454,10 +454,10 @@ export default class InputNumber extends React.Component {
     if (value || value === 0) {
       if (!isNaN(value)) {
         const val = Number(value);
-        if (val >= props.max) {
+        if (val > props.max) {
           upDisabledClass = `${prefixCls}-handler-up-disabled`;
         }
-        if (val <= props.min) {
+        if (val < props.min) {
           downDisabledClass = `${prefixCls}-handler-down-disabled`;
         }
       } else {


### PR DESCRIPTION
this fixes issue [ant-design/ant-design#8529](https://github.com/ant-design/ant-design/issues/8592)

The down and up functions are infinite recursive when the value is equal to min or max value because the up and down classes are getting disabled before they should be disabled this stop the stop function(this.stop) from getting called onMouseUp therefore causing infinite recursion.