### PR TITLE
Standard change event for react

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,13 @@ export default class InputNumber extends React.Component {
     }
     const input = this.props.parser(this.getValueFromEvent(e));
     this.setState({ inputValue: input });
-    this.props.onChange(this.toNumberWhenUserInput(input)); // valid number or invalid string
+    const evt = {
+      target: {
+        name: this.props.name,
+        value: this.toNumberWhenUserInput(input)
+      }
+    };
+    this.props.onChange(evt); // valid number or invalid string
   }
 
   onFocus = (...args) => {


### PR DESCRIPTION
The event generated from the input box does not follow the react event format, this fixes it and passed the input name as well as value in the event param.