### PR TITLE
Fix focus shown in ant-design #10663

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "./node_modules/rc-tools/lib/eslintrc"
+  ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -137,18 +137,23 @@ export default class InputNumber extends React.Component {
     if (!this.pressingUpOrDown) {
       return;
     }
+
     if (this.props.focusOnUpDown && this.state.focused) {
       const selectionRange = this.input.setSelectionRange;
       if (selectionRange &&
-          typeof selectionRange === 'function' &&
-          this.start !== undefined &&
-          this.end !== undefined) {
+        typeof selectionRange === 'function' &&
+        this.start !== this.end &&
+        this.start !== undefined &&
+        this.end !== undefined
+      ) {
         this.input.setSelectionRange(this.start, this.end);
-      } else {
-        this.focus();
       }
-      this.pressingUpOrDown = false;
+      if (document.activeElement !== this.input) {
+        this.input.focus();
+      }
     }
+
+    this.pressingUpOrDown = false;
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
1. Fix https://github.com/ant-design/ant-design/issues/10663; The problem is setSelection does not automatically focus the input element
2. Add eslint, let editor can fix styles and detect errors automatically.
3. Fix the cursor problem in increase; for example `9<cursor/>` after increase will become `1<cursor/>0`;  In this PR, we will let setSelection happens when and only when the selection is expanded