### PR TITLE
Add decimal separator prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rc-input-number
+﻿# rc-input-number
 ---
 
 input number ui component for react
@@ -204,6 +204,12 @@ online example: http://react-component.github.io/input-number/examples/
           <td>string</td>
           <td></td>
           <td>Specifies a regex pattern to be added to the input number element - useful for forcing iOS to open the number pad instead of the normal keyboard (supply a regex of "\d*" to do this) or form validation</td>
+        </tr>
+	<tr>
+          <td>separator</td>
+          <td>string</td>
+          <td></td>
+          <td>Specifies the decimal separator</td>
         </tr>
     </tbody>
 </table>

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ export default class InputNumber extends React.Component {
     precision: PropTypes.number,
     required: PropTypes.bool,
     pattern: PropTypes.string,
+    separator: PropTypes.string,
   }
 
   static defaultProps = {
@@ -285,7 +286,13 @@ export default class InputNumber extends React.Component {
   getValueFromEvent(e) {
     // optimize for chinese input expierence
     // https://github.com/ant-design/ant-design/issues/8196
-    return e.target.value.trim().replace(/。/g, '.');
+    let value = e.target.value.trim().replace(/。/g, '.');
+
+    if ('separator' in this.props) {
+      value = value.replace(this.props.separator, '.');
+    }
+
+    return value;
   }
 
   getValidValue(value, min = this.props.min, max = this.props.max) {
@@ -664,7 +671,13 @@ export default class InputNumber extends React.Component {
         onMouseLeave: this.stop,
       };
     }
-    const inputDisplayValueFormat = this.formatWrapper(inputDisplayValue);
+
+    let inputDisplayValueFormat = this.formatWrapper(inputDisplayValue);
+    if ('separator' in this.props) {
+      inputDisplayValueFormat = inputDisplayValueFormat
+        .toString()
+        .replace('.', this.props.separator);
+    }
     const isUpDisabled = !!upDisabledClass || disabled || readOnly;
     const isDownDisabled = !!downDisabledClass || disabled || readOnly;
     // ref for test


### PR DESCRIPTION
This will add decimal separator prop.
A thing to notice is the parser prop doesn't adjust to this prop, this allows the custom separator as well as a dot to be used for input but the displaying value will show the custom separator.
I guess people will just have to pass a parser prop if they don't want a dot to be used?