### PR TITLE
Autocomplete attribute customizable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -647,7 +647,7 @@ export default class InputNumber extends React.Component {
     for (const key in props) {
       if (
         props.hasOwnProperty(key) &&
-        (key.substr(0, 5) === 'data-' || key.substr(0, 5) === 'aria-' || key === 'role')
+        (key.substr(0, 5) === 'data-' || key.substr(0, 5) === 'aria-' || key === 'role' || key === 'autocomplete')
       ) {
         dataOrAriaAttributeProps[key] = props[key];
       }
@@ -752,7 +752,7 @@ export default class InputNumber extends React.Component {
             onMouseUp={this.onMouseUp}
             className={`${prefixCls}-input`}
             tabIndex={props.tabIndex}
-            autoComplete="off"
+            autocomplete="off"
             onFocus={this.onFocus}
             onBlur={this.onBlur}
             onKeyDown={editable ? this.onKeyDown : noop}

--- a/src/index.js
+++ b/src/index.js
@@ -744,10 +744,12 @@ export default class InputNumber extends React.Component {
           aria-valuemax={props.max}
           aria-valuenow={value}
         >
+{
+
           <input
             required={props.required}
             type={props.type}
-            placeholder={props.placeholder}
+            placeholder={props.placeholder} // eslint-disable-line react/no-unknown-property
             onClick={props.onClick}
             onMouseUp={this.onMouseUp}
             className={`${prefixCls}-input`}

--- a/src/index.js
+++ b/src/index.js
@@ -647,7 +647,8 @@ export default class InputNumber extends React.Component {
     for (const key in props) {
       if (
         props.hasOwnProperty(key) &&
-        (key.substr(0, 5) === 'data-' || key.substr(0, 5) === 'aria-' || key === 'role' || key === 'autocomplete')
+        (key.substr(0, 5) === 'data-' || key.substr(0, 5) === 'aria-' ||
+         key === 'role' || key === 'autocomplete')
       ) {
         dataOrAriaAttributeProps[key] = props[key];
       }
@@ -744,17 +745,15 @@ export default class InputNumber extends React.Component {
           aria-valuemax={props.max}
           aria-valuenow={value}
         >
-{
-
           <input
             required={props.required}
             type={props.type}
-            placeholder={props.placeholder} // eslint-disable-line react/no-unknown-property
+            placeholder={props.placeholder}
             onClick={props.onClick}
             onMouseUp={this.onMouseUp}
             className={`${prefixCls}-input`}
             tabIndex={props.tabIndex}
-            autocomplete="off"
+            autocomplete="off" // eslint-disable-line react/no-unknown-property
             onFocus={this.onFocus}
             onBlur={this.onBlur}
             onKeyDown={editable ? this.onKeyDown : noop}


### PR DESCRIPTION
Apparently, using `autoComplete` with capital C is not recognized by Chrome as well as the `"off"` value. This is why I am proposing to make the autocomplete attribute customizable in order to be able to apply a workaround that works for me. Something like this `autocomplete="no"`.