### PR TITLE
fix InputNumber在父页面组件update并re-render的时候，会失去自身之前的数字选中状态

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ export default class InputNumber extends React.Component {
 
         if (
           // If not match full str, try to match part of str
-          !this.partRestoreByAfter(this.cursorAfter)
+          !this.partRestoreByAfter(this.cursorAfter) && this.state.value !== this.props.value
         ) {
           // If not match any of then, let's just keep the position
           // TODO: Logic should not reach here, need check if happens

--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ export default class InputNumber extends React.Component {
 
         if (
           // If not match full str, try to match part of str
-          !this.partRestoreByAfter(this.cursorAfter)
+          !this.partRestoreByAfter(this.cursorAfter) && this.state.value !== this.props.value
         ) {
           // If not match any of then, let's just keep the position
           // TODO: Logic should not reach here, need check if happens
@@ -533,7 +533,7 @@ export default class InputNumber extends React.Component {
     if (typeof val === 'number') {
       result =
         ((precisionFactor * val + precisionFactor * step * rat) /
-        precisionFactor).toFixed(precision);
+          precisionFactor).toFixed(precision);
     } else {
       result = min === -Infinity ? step : min;
     }
@@ -548,7 +548,7 @@ export default class InputNumber extends React.Component {
     if (typeof val === 'number') {
       result =
         ((precisionFactor * val - precisionFactor * step * rat) /
-        precisionFactor).toFixed(precision);
+          precisionFactor).toFixed(precision);
     } else {
       result = min === -Infinity ? -step : min;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ export default class InputNumber extends React.Component {
 
         if (
           // If not match full str, try to match part of str
-          !this.partRestoreByAfter(this.cursorAfter) && this.state.value !== this.props.value
+          !this.partRestoreByAfter(this.cursorAfter)
         ) {
           // If not match any of then, let's just keep the position
           // TODO: Logic should not reach here, need check if happens
@@ -533,7 +533,7 @@ export default class InputNumber extends React.Component {
     if (typeof val === 'number') {
       result =
         ((precisionFactor * val + precisionFactor * step * rat) /
-          precisionFactor).toFixed(precision);
+        precisionFactor).toFixed(precision);
     } else {
       result = min === -Infinity ? step : min;
     }
@@ -548,7 +548,7 @@ export default class InputNumber extends React.Component {
     if (typeof val === 'number') {
       result =
         ((precisionFactor * val - precisionFactor * step * rat) /
-          precisionFactor).toFixed(precision);
+        precisionFactor).toFixed(precision);
     } else {
       result = min === -Infinity ? -step : min;
     }


### PR DESCRIPTION
ref #https://github.com/ant-design/ant-design/issues/12808

![1](https://user-images.githubusercontent.com/8358236/47429346-af57d480-d7c8-11e8-85ff-47e1ca212297.gif)


