### PR TITLE
fix input value resetting when parent rerenders with the same value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ export default class InputNumber extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if ('value' in nextProps) {
+    if ('value' in nextProps && nextProps.value !== this.props.value) {
       const value = this.state.focused
         ? nextProps.value : this.getValidValue(nextProps.value, nextProps.min, nextProps.max);
       this.setState({

--- a/tests/index.js
+++ b/tests/index.js
@@ -952,6 +952,10 @@ describe('inputNumber', () => {
           min: 0,
           max: 20,
         };
+        onChange = (value) => {
+          this.setValue(value);
+          onChange(value);
+        }
         setMax(max) {
           this.setState({ max });
         }
@@ -966,7 +970,7 @@ describe('inputNumber', () => {
             <InputNumber
               ref="inputNum"
               value={this.state.value}
-              onChange={onChange}
+              onChange={this.onChange}
               max={this.state.max}
               min={this.state.min}
             />

--- a/tests/index.js
+++ b/tests/index.js
@@ -990,6 +990,38 @@ describe('inputNumber', () => {
       expect(inputElement.value).to.be('14');
       expect(onChange.calledWith(14)).to.be(true);
     });
+
+    // https://github.com/react-component/input-number/issues/120
+    it('should not reset value when parent rerenders with the same `value` prop', () => {
+      class Demo extends React.Component {
+        state = { value: 40 };
+
+        onChange = () => {
+          this.forceUpdate();
+        };
+
+        render() {
+          return (
+            <InputNumber
+              ref="inputNum"
+              value={this.state.value}
+              onChange={this.onChange}
+            />
+          );
+        }
+      }
+
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.input);
+
+      Simulate.focus(inputElement);
+      Simulate.change(inputElement, { target: { value: '401' } });
+
+      // Demo rerenders and the `value` prop is still 40, but the user input should
+      // be retained
+      expect(inputElement.value).to.be('401');
+    });
   });
 
   describe(`required prop`, () => {


### PR DESCRIPTION
fixes #120 

I added a check in `componentWillReceiveProps` that ensures that the value changed