### PR TITLE
Fixed invalidation of a number with a period + trailing 0's

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "dependencies": {
     "babel-runtime": "6.x",
     "classnames": "^2.2.0",
-    "is-negative-zero": "^2.0.0",
     "prop-types": "^15.5.7",
     "rmc-feedback": "^2.0.0",
     "rc-util": "^4.5.1"

--- a/src/index.js
+++ b/src/index.js
@@ -525,7 +525,9 @@ export default class InputNumber extends React.Component {
   }
 
   toNumber(num) {
-    if (this.isNotCompleteNumber(num) || (num.length > 16 && this.state.focused)) {
+    // num.length > 16 => This is to prevent input of large numbers
+    const numberIsTooLarge = num.length > 16 && this.state.focused;
+    if (this.isNotCompleteNumber(num) || numberIsTooLarge) {
       return num;
     }
     if (isValidProps(this.props.precision)) {

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ export default class InputNumber extends React.Component {
         ? nextProps.value : this.getValidValue(nextProps.value, nextProps.min, nextProps.max);
       this.setState({
         value,
-        inputValue: this.inputting ? this.enteredInput : this.toPrecisionAsStep(value),
+        inputValue: this.inputting ? this.rawInput : this.toPrecisionAsStep(value),
       });
     }
 
@@ -255,9 +255,9 @@ export default class InputNumber extends React.Component {
     if (this.state.focused) {
       this.inputting = true;
     }
-    this.enteredInput = this.props.parser(this.getValueFromEvent(e));
-    this.setState({ inputValue: this.enteredInput });
-    onChange(this.toNumberWhenUserInput(this.enteredInput)); // valid number or invalid string
+    this.rawInput = this.props.parser(this.getValueFromEvent(e));
+    this.setState({ inputValue: this.rawInput });
+    onChange(this.toNumber(this.rawInput)); // valid number or invalid string
   }
 
   onMouseUp = (...args) => {
@@ -525,22 +525,13 @@ export default class InputNumber extends React.Component {
   }
 
   toNumber(num) {
-    if (this.isNotCompleteNumber(num)) {
+    if (this.isNotCompleteNumber(num) || (num.length > 16 && this.state.focused)) {
       return num;
     }
     if (isValidProps(this.props.precision)) {
       return Number(Number(num).toFixed(this.props.precision));
     }
     return Number(num);
-  }
-
-  // '1.0' '1.00'  => may be a inputing number
-  toNumberWhenUserInput(num) {
-    // num.length > 16 => prevent input large number will became Infinity
-    if (num.length > 16 && this.state.focused) {
-      return num;
-    }
-    return this.toNumber(num);
   }
 
   upStep(val, rat) {

--- a/src/index.js
+++ b/src/index.js
@@ -526,7 +526,7 @@ export default class InputNumber extends React.Component {
 
   toNumber(num) {
     // num.length > 16 => This is to prevent input of large numbers
-    const numberIsTooLarge = num.length > 16 && this.state.focused;
+    const numberIsTooLarge = num && num.length > 16 && this.state.focused;
     if (this.isNotCompleteNumber(num) || numberIsTooLarge) {
       return num;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -533,32 +533,22 @@ export default class InputNumber extends React.Component {
   }
 
   upStep(val, rat) {
-    const { step, min } = this.props;
+    const { step } = this.props;
     const precisionFactor = this.getPrecisionFactor(val, rat);
     const precision = Math.abs(this.getMaxPrecision(val, rat));
-    let result;
-    if (typeof val === 'number') {
-      result =
-        ((precisionFactor * val + precisionFactor * step * rat) /
-        precisionFactor).toFixed(precision);
-    } else {
-      result = min === -Infinity ? step : min;
-    }
+    const result =
+    ((precisionFactor * val + precisionFactor * step * rat) /
+    precisionFactor).toFixed(precision);
     return this.toNumber(result);
   }
 
   downStep(val, rat) {
-    const { step, min } = this.props;
+    const { step } = this.props;
     const precisionFactor = this.getPrecisionFactor(val, rat);
     const precision = Math.abs(this.getMaxPrecision(val, rat));
-    let result;
-    if (typeof val === 'number') {
-      result =
-        ((precisionFactor * val - precisionFactor * step * rat) /
-        precisionFactor).toFixed(precision);
-    } else {
-      result = min === -Infinity ? -step : min;
-    }
+    const result =
+    ((precisionFactor * val - precisionFactor * step * rat) /
+    precisionFactor).toFixed(precision);
     return this.toNumber(result);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -118,9 +118,17 @@ export default class InputNumber extends React.Component {
     if ('value' in nextProps && nextProps.value !== this.props.value) {
       const value = this.state.focused
         ? nextProps.value : this.getValidValue(nextProps.value, nextProps.min, nextProps.max);
+      let nextInputValue;
+      if (this.pressingUpOrDown) {
+        nextInputValue = value;
+      } else if (this.inputting) {
+        nextInputValue = this.rawInput;
+      } else {
+        nextInputValue = this.toPrecisionAsStep(value);
+      }
       this.setState({
         value,
-        inputValue: this.inputting ? this.rawInput : this.toPrecisionAsStep(value),
+        inputValue: nextInputValue,
       });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ export default class InputNumber extends React.Component {
         ? nextProps.value : this.getValidValue(nextProps.value, nextProps.min, nextProps.max);
       this.setState({
         value,
-        inputValue: this.inputting ? value : this.toPrecisionAsStep(value),
+        inputValue: this.inputting ? this.enteredInput : this.toPrecisionAsStep(value),
       });
     }
 
@@ -248,12 +248,16 @@ export default class InputNumber extends React.Component {
   }
 
   onChange = (e) => {
+    const {
+      onChange,
+    } = this.props;
+
     if (this.state.focused) {
       this.inputting = true;
     }
-    const input = this.props.parser(this.getValueFromEvent(e));
-    this.setState({ inputValue: input });
-    this.props.onChange(this.toNumberWhenUserInput(input)); // valid number or invalid string
+    this.enteredInput = this.props.parser(this.getValueFromEvent(e));
+    this.setState({ inputValue: this.enteredInput });
+    onChange(this.toNumberWhenUserInput(this.enteredInput)); // valid number or invalid string
   }
 
   onMouseUp = (...args) => {
@@ -533,7 +537,7 @@ export default class InputNumber extends React.Component {
   // '1.0' '1.00'  => may be a inputing number
   toNumberWhenUserInput(num) {
     // num.length > 16 => prevent input large number will became Infinity
-    if ((/\.\d*0$/.test(num) || num.length > 16) && this.state.focused) {
+    if (num.length > 16 && this.state.focused) {
       return num;
     }
     return this.toNumber(num);

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import isNegativeZero from 'is-negative-zero';
 import KeyCode from 'rc-util/lib/KeyCode';
 import InputHandler from './InputHandler';
 
@@ -491,9 +490,6 @@ export default class InputNumber extends React.Component {
   formatWrapper(num) {
     // http://2ality.com/2012/03/signedzero.html
     // https://github.com/ant-design/ant-design/issues/9439
-    if (isNegativeZero(num)) {
-      return '-0';
-    }
     if (this.props.formatter) {
       return this.props.formatter(num);
     }

--- a/tests/index.js
+++ b/tests/index.js
@@ -832,14 +832,14 @@ describe('inputNumber', () => {
       Simulate.focus(inputElement);
       Simulate.change(inputElement, { target: { value: '6.0' } });
       expect(inputElement.value).to.be('6.0');
-      expect(num).to.be('6.0');
+      expect(num).to.be(6);
       Simulate.blur(inputElement);
       expect(inputElement.value).to.be('6');
       expect(num).to.be(6);
       Simulate.focus(inputElement);
       Simulate.change(inputElement, { target: { value: '6.10' } });
       expect(inputElement.value).to.be('6.10');
-      expect(num).to.be('6.10');
+      expect(num).to.be(6.1);
       Simulate.blur(inputElement);
       expect(inputElement.value).to.be('6.1');
       expect(num).to.be(6.1);


### PR DESCRIPTION
I noticed that everytime I enter in a number with a period followed by trailing 0's, I would be getting a string back which would trip up my validation on the ANTD side of things.
For example:
Input: '1.0000'
Value to be displayed: '1.0000'
Value to be returned from onChange function: 1

however what I was getting was:
Input: '1.0000'
Value to be displayed: '1.0000'
Value to be returned from onChange function: '1.00'

in which the validation would pick it up as not a number and show an error message while I was in focus of the component. It was fixed when I stopped focusing on the component but having '1.00 is not a number' is incorrect behaviour.

My change fixes that and now numbers with a decimal + trailing 0's are considered valid numbers. They are displayed properly and returned to the user as a number.

Fixes https://github.com/ant-design/ant-design/issues/15575