### PR TITLE
chore: Use Math.round other than toFixed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -536,7 +536,8 @@ export default class InputNumber extends React.Component {
       return num;
     }
     if (isValidProps(this.props.precision)) {
-      return Number(Number(num).toFixed(this.props.precision));
+      return Math.round(num * Math.pow(10, this.props.precision)) /
+             Math.pow(10, this.props.precision);
     }
     return Number(num);
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1198,6 +1198,14 @@ describe('inputNumber', () => {
       Simulate.blur(inputElement);
       expect(onChangeFirstArgument).to.be(3.46);
       expect(inputElement.value).to.be('3.46');
+      Simulate.change(inputElement, { target: { value: '3.465' } });
+      Simulate.blur(inputElement);
+      expect(onChangeFirstArgument).to.be(3.47);
+      expect(inputElement.value).to.be('3.47');
+      Simulate.change(inputElement, { target: { value: '3.455' } });
+      Simulate.blur(inputElement);
+      expect(onChangeFirstArgument).to.be(3.46);
+      expect(inputElement.value).to.be('3.46');
       Simulate.change(inputElement, { target: { value: '1' } });
       Simulate.blur(inputElement);
       expect(onChangeFirstArgument).to.be(1);


### PR DESCRIPTION
Replace toFixed() by Math.round(), because toFixed() follow Banker's Round
https://blog.csdn.net/fjnpysh/article/details/79077997