### PR TITLE
allow string of length greater than 16 to be passed as value/defaultV…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -534,8 +534,9 @@ export default class InputNumber extends React.Component {
   }
 
   toNumber(num) {
+    const focused = this.state ? this.state.focused : this.props.autoFocus;
     // num.length > 16 => This is to prevent input of large numbers
-    const numberIsTooLarge = num && num.length > 16 && this.state.focused;
+    const numberIsTooLarge = num && num.length > 16 && focused;
     if (this.isNotCompleteNumber(num) || numberIsTooLarge) {
       return num;
     }

--- a/tests/index.js
+++ b/tests/index.js
@@ -613,6 +613,18 @@ describe('inputNumber', () => {
       inputElement = ReactDOM.findDOMNode(inputNumber.input);
       expect(inputNumber.state.value).to.be(0);
     });
+
+    it('default value can be a string greater than 16 characters', () => {
+      const Demo = createReactClass({
+        render() {
+          return <InputNumber ref="inputNum" max={10} defaultValue={'-3.637978807091713e-12'} />;
+        },
+      });
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.input);
+      expect(inputNumber.state.value).to.be(-3.637978807091713e-12);
+    });
   });
 
   describe('value', () => {
@@ -638,6 +650,18 @@ describe('inputNumber', () => {
       inputNumber = example.refs.inputNum;
       inputElement = ReactDOM.findDOMNode(inputNumber.input);
       expect(inputNumber.state.value).to.be(0);
+    });
+
+    it('value can be a string greater than 16 characters', () => {
+      const Demo = createReactClass({
+        render() {
+          return <InputNumber ref="inputNum" max={10} value={'-3.637978807091713e-12'} />;
+        },
+      });
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.input);
+      expect(inputNumber.state.value).to.be(-3.637978807091713e-12);
     });
   });
 


### PR DESCRIPTION
previously if someone passed a string of length greater than 16 as value/defaultValue, the component would error out. this was because the constructor call of toNumber (which had the line `const numberIsTooLarge = num && num.length > 16 && this.state.focused;`) was trying to access a state variable before this.state was actually defined.