### PR TITLE
Pass the `title` prop down to the actual input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -799,6 +799,7 @@ export default class InputNumber extends React.Component {
             min={props.min}
             step={props.step}
             name={props.name}
+            title={props.title}
             id={props.id}
             onChange={this.onChange}
             ref={this.saveInput}


### PR DESCRIPTION
This pr fixes a bug, where the title prop never gets added to the actual input.
Here's the original issue (from ant-design) where this was discovered: https://github.com/ant-design/ant-design/issues/13410