### PR TITLE
input number default props type number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,7 @@ export default class InputNumber extends React.Component {
     parser: defaultParser,
     required: false,
     autoComplete: 'off',
+    type: 'number',
   }
 
   constructor(props) {


### PR DESCRIPTION
If <input /> elem not blur, letter is allow to input, and user jump press enter key will submit the illegality value.
And add the type="number" attr will avoid this problem.