### PR TITLE
fix: autoStep is not work after triggering input event(#22528)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -180,8 +180,6 @@ export default class InputNumber extends React.Component {
         this.focus();
       }
     }
-
-    this.pressingUpOrDown = false;
   }
 
   componentWillUnmount() {
@@ -594,6 +592,8 @@ export default class InputNumber extends React.Component {
     this.setValue(val);
     this.setState({
       focused: true,
+    }, () => {
+      this.pressingUpOrDown = false;
     });
     if (outOfRange) {
       return;


### PR DESCRIPTION
@afc163  之前在每次渲染后都将`pressingUpOrDown`设为`false`,导致触发`input`事件后，按住向上箭头时，在执行下面代码的时候：
``` js
if (!isEqual(prevProps.value, value) ||
        !isEqual(prevProps.max, max) ||
        !isEqual(prevProps.min, min)) {
        const validValue = focused ? value : this.getValidValue(value);
        let nextInputValue;
        if (this.pressingUpOrDown) {
          nextInputValue = validValue;
        } else if (this.inputting) {
          nextInputValue = this.rawInput;
        } else {
          nextInputValue = this.toPrecisionAsStep(validValue);
        }
        this.setState({ // eslint-disable-line
          value: validValue,
          inputValue: nextInputValue,
        });
      }
```
取的是`rawInput`的值（可能是由于渲染的问题，渲染一次后下次再取`pressingUpOrDown`的时候就成为了`false`，但是如果不按住箭头的话就没有问题，这个原因我还没有查明白）

现在我把`this.pressingUpOrDown = false`放在`step`方法的最后`setState`的回调里面，效果和之前应该是相同的，不知道有什么问题？

[#22528](https://github.com/ant-design/ant-design/issues/22528)