### PR TITLE
Add onPaste prop 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -630,7 +630,7 @@ export default class InputNumber extends React.Component {
       upHandler, downHandler, className, max, min,
       style, title, onMouseEnter, onMouseLeave, onMouseOver, onMouseOut,
       required, onClick, tabIndex, type, placeholder, id, inputMode, pattern,
-      step, maxLength, autoFocus, name,
+      step, maxLength, autoFocus, name, onPaste,
       ...rest
     } = this.props;
     const { value, focused } = this.state;
@@ -744,6 +744,7 @@ export default class InputNumber extends React.Component {
             required={required}
             type={type}
             placeholder={placeholder}
+            onPaste={onPaste}
             onClick={onClick}
             onMouseUp={this.onMouseUp}
             className={`${prefixCls}-input`}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1812,6 +1812,28 @@ describe('InputNumber', () => {
     });
   });
 
+  describe('onPaste props', () => {
+    it ('passes onPaste event handler', () => {
+      const onPaste = sinon.spy();
+      const Demo = createReactClass({
+        render() {
+          return (
+            <InputNumber
+              value={1}
+              ref="inputNum"
+              onPaste={onPaste}
+            />
+          );
+        },
+      });
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.input);
+      Simulate.paste(inputElement);
+      expect(onPaste.called).to.be(true);
+    });
+  });
+
   describe('aria and data props', () => {
     it('passes data-* attributes', () => {
       const Demo = createReactClass({


### PR DESCRIPTION
### Why
- Someone like me might need to pass `onPaste` handler to input.

### Descriptions
- Destructuring `onPaste` from props and pass it to input dom.