### PR TITLE
feat: trigger props.onStep when value stepps up/down

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -613,6 +613,7 @@ class InputNumber extends React.Component<Partial<InputNumberProps>, InputNumber
       val = props.min;
     }
     this.setValue(val, null);
+    if (props.onStep) props.onStep(val, { offset: ratio, type });
     this.setState(
       {
         focused: true,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1822,6 +1822,25 @@ describe('InputNumber', () => {
     });
   });
 
+  describe('onStep props', () => {
+    it('triggers onStep when stepping value up or down', () => {
+      const onStep = sinon.spy();
+      class Demo extends React.Component {
+        render() {
+          return <InputNumber value={1} ref="inputNum" onStep={onStep} />;
+        }
+      }
+      example = ReactDOM.render(<Demo />, container);
+      inputNumber = example.refs.inputNum;
+      inputElement = ReactDOM.findDOMNode(inputNumber.input);
+      Simulate.keyDown(inputElement, {
+        keyCode: keyCode.UP,
+      });
+      expect(onStep.called).to.be(true);
+      expect(onStep.calledWith(2)).to.be(true);
+    });
+  });
+
   describe('aria and data props', () => {
     it('passes data-* attributes', () => {
       class Demo extends React.Component {


### PR DESCRIPTION
... to tell the source of the value change

In certain scenarios, such as Yuque Show, value changes are only necessary to handle in following cases:
- enter pressed
- blurred
- value stepped by clicking or pressing up/down arrow

props.onChange triggers too often since any temporary edits change value. 