### PR TITLE
feat(useUpdateEffect): support ssr

### DIFF
--- a/src/hooks/useLayoutEffect.ts
+++ b/src/hooks/useLayoutEffect.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+const isBrowser = typeof window !== 'undefined' && window.document && window.document.createElement;
+
+export const useLayoutEffect = isBrowser ? React.useLayoutEffect : React.useEffect;

--- a/src/hooks/useLayoutEffect.ts
+++ b/src/hooks/useLayoutEffect.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
+import canUseDom from 'rc-util/lib/Dom/canUseDom';
 
-const isBrowser = typeof window !== 'undefined' && window.document && window.document.createElement;
-
-export const useLayoutEffect = isBrowser ? React.useLayoutEffect : React.useEffect;
+export const useLayoutEffect = canUseDom() ? React.useLayoutEffect : React.useEffect;

--- a/src/hooks/useUpdateEffect.ts
+++ b/src/hooks/useUpdateEffect.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useLayoutEffect } from './useLayoutEffect';
 
 /**
  * Work as `componentDidUpdate`
@@ -6,7 +7,7 @@ import * as React from 'react';
 export default function useUpdateEffect(callback: () => void | (() => void), condition: any[]) {
   const initRef = React.useRef(false);
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!initRef.current) {
       initRef.current = true;
       return undefined;


### PR DESCRIPTION
fix the `useLayoutEffect` warning of `nextjs`：

`
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
`

close #302 