### PR TITLE
fix:keydown when keycode.enter,controlled inputnumber can't flush value

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -409,7 +409,9 @@ const InputNumber = React.forwardRef(
       userTypingRef.current = true;
 
       if (which === KeyCode.ENTER) {
-        userTypingRef.current = false;
+        if(!compositionRef.current) { 
+          userTypingRef.current = false;
+        }
         flushInputValue();
         onPressEnter?.(event);
       }

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -409,6 +409,7 @@ const InputNumber = React.forwardRef(
       userTypingRef.current = true;
 
       if (which === KeyCode.ENTER) {
+        userTypingRef.current = false;
         flushInputValue();
         onPressEnter?.(event);
       }

--- a/tests/input.test.tsx
+++ b/tests/input.test.tsx
@@ -114,6 +114,9 @@ describe('InputNumber.Input', () => {
     wrapper.changeValue('3');
     wrapper.find('input').simulate('keyDown', { which: KeyCode.ENTER });
     expect(wrapper.getInputValue()).toEqual('3');
+    wrapper.changeValue('5');
+    wrapper.find('input').simulate('keyDown', { which: KeyCode.ENTER });
+    expect(wrapper.getInputValue()).toEqual('5');
   });
 
   describe('empty on blur should trigger null', () => {

--- a/tests/input.test.tsx
+++ b/tests/input.test.tsx
@@ -94,6 +94,28 @@ describe('InputNumber.Input', () => {
     expect(onPressEnter).toHaveBeenCalled();
   });
 
+  it('pressEnter value should be ok', () => {
+    const Demo = () => {
+      const [value, setValue] = React.useState(1);
+      const inputRef = React.useRef<HTMLInputElement>(null)
+      return (
+        <InputNumber
+          ref={inputRef}
+          value={value}
+          onPressEnter={() => {
+            setValue(Number(inputRef.current.value));
+          }}
+        />
+      );
+    };
+
+    const wrapper = mount(<Demo />);
+    wrapper.focusInput();
+    wrapper.changeValue('3');
+    wrapper.find('input').simulate('keyDown', { which: KeyCode.ENTER });
+    expect(wrapper.getInputValue()).toEqual('3');
+  });
+
   describe('empty on blur should trigger null', () => {
     it('basic', () => {
       const onChange = jest.fn();


### PR DESCRIPTION
fix #305 
fix https://github.com/ant-design/ant-design/issues/29991