### PR TITLE
fix: check mergePrecision should consider zero

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -285,7 +285,7 @@ const InputNumber = React.forwardRef(
       if (!readOnly && !disabled) {
         const numStr = updateValue.toString();
         const mergedPrecision = getPrecision(numStr, userTyping);
-        if (mergedPrecision>=0) {
+        if (mergedPrecision >= 0) {
           updateValue = getMiniDecimal(toFixed(numStr, '.', mergedPrecision));
         }
 

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -285,7 +285,7 @@ const InputNumber = React.forwardRef(
       if (!readOnly && !disabled) {
         const numStr = updateValue.toString();
         const mergedPrecision = getPrecision(numStr, userTyping);
-        if (mergedPrecision) {
+        if (mergedPrecision>=0) {
           updateValue = getMiniDecimal(toFixed(numStr, '.', mergedPrecision));
         }
 

--- a/tests/decimal.test.tsx
+++ b/tests/decimal.test.tsx
@@ -115,6 +115,16 @@ describe('InputNumber.Decimal', () => {
       expect(wrapper.getInputValue()).toEqual('1.00');
     });
 
+    it('zero precision should work',()=>{
+      const onChange = jest.fn();
+      const wrapper = mount(<InputNumber onChange={onChange} precision={0} />);
+
+      wrapper.changeValue('1.44');
+      wrapper.blurInput();
+      expect(onChange).toHaveBeenCalledWith(1);
+      expect(wrapper.getInputValue()).toEqual('1');
+    })
+
     it('should not trigger onChange when blur InputNumber with precision', () => {
       const onChange = jest.fn();
       const wrapper = mount(<InputNumber precision={2} defaultValue={2} onChange={onChange} />);


### PR DESCRIPTION
Fix ant-design/ant-design#30045, should consider `mergedPrecision` equals zero.