### PR TITLE
fix(onChange): should trigger onChange when removing value

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -318,7 +318,7 @@ const InputNumber = React.forwardRef(
       if (!compositionRef.current) {
         const finalValue = mergedParser(inputStr);
         const finalDecimal = getMiniDecimal(finalValue);
-        if (!finalDecimal.isInvalidate()) {
+        if (!finalDecimal.isNaN()) {
           triggerValueUpdate(finalDecimal, true);
         }
       }

--- a/tests/decimal.test.tsx
+++ b/tests/decimal.test.tsx
@@ -161,6 +161,15 @@ describe('InputNumber.Decimal', () => {
       wrapper.changeValue('')
       expect(wrapper.getInputValue()).toEqual('');
       expect(onChange).toHaveBeenCalledWith(null);
+
+      wrapper.setProps({min:0,max:10})
+      wrapper.changeValue('2')
+      expect(wrapper.getInputValue()).toEqual('2')
+      expect(onChange).toHaveBeenCalledWith(2)
+
+      wrapper.changeValue('')
+      expect(wrapper.getInputValue()).toEqual('')
+      expect(onChange).toHaveBeenCalledWith(null)
     })
   });
 });

--- a/tests/decimal.test.tsx
+++ b/tests/decimal.test.tsx
@@ -148,5 +148,19 @@ describe('InputNumber.Decimal', () => {
       expect(onChange).toHaveBeenCalledWith(null);
       expect(wrapper.getInputValue()).toEqual('');
     });
+
+    it('should trigger onChange when removing value',()=>{
+      const onChange = jest.fn();
+      const wrapper = mount(<InputNumber onChange={onChange} />);
+
+      wrapper.focusInput();
+      wrapper.changeValue('1');
+      expect(wrapper.getInputValue()).toEqual('1');
+      expect(onChange).toHaveBeenCalledWith(1);
+
+      wrapper.changeValue('')
+      expect(wrapper.getInputValue()).toEqual('');
+      expect(onChange).toHaveBeenCalledWith(null);
+    })
   });
 });

--- a/tests/github.test.tsx
+++ b/tests/github.test.tsx
@@ -206,7 +206,7 @@ describe('InputNumber.Github', () => {
 
     wrapper.focusInput();
     wrapper.changeValue('');
-    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(2);
     expect(onInput).toHaveBeenCalledTimes(2);
     expect(onInput).toHaveBeenCalledWith('');
 

--- a/tests/input.test.tsx
+++ b/tests/input.test.tsx
@@ -99,7 +99,7 @@ describe('InputNumber.Input', () => {
       const onChange = jest.fn();
       const wrapper = mount(<InputNumber defaultValue="1" onChange={onChange} />);
       wrapper.changeValue('');
-      expect(onChange).not.toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith(null);
 
       wrapper.blurInput();
       expect(onChange).toHaveBeenLastCalledWith(null);
@@ -109,7 +109,7 @@ describe('InputNumber.Input', () => {
       const onChange = jest.fn();
       const wrapper = mount(<InputNumber min="1" defaultValue="11" onChange={onChange} />);
       wrapper.changeValue('');
-      expect(onChange).not.toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalled();
 
       wrapper.blurInput();
       expect(onChange).toHaveBeenLastCalledWith(null);


### PR DESCRIPTION
Fix ant-design/ant-design#30096. I'm not sure whether should trigger `onChange` when `defaultValue` is provided and `changeValue('')` (I think `onChange` should be triggered ?) and I change some original tests. Feel free to close it if it's not reasonable. 