### PR TITLE
fix: defaultValue wrongly overrode value (antd#30873)

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -113,7 +113,7 @@ const InputNumber = React.forwardRef(
     // ============================ Value =============================
     // Real value control
     const [decimalValue, setDecimalValue] = React.useState<DecimalClass>(() =>
-      getMiniDecimal(defaultValue ?? value),
+      getMiniDecimal(value ?? defaultValue),
     );
 
     function setUncontrolledDecimalValue(newDecimal: DecimalClass) {

--- a/tests/props.test.tsx
+++ b/tests/props.test.tsx
@@ -282,6 +282,11 @@ describe('InputNumber.Props', () => {
       expect(wrapper.getInputValue()).toEqual('9');
       expect(wrapper.exists('.rc-input-number-out-of-range')).toBeFalsy();
     });
+
+    it('value can override given defaultValue', () => {
+      const wrapper = mount(<InputNumber value={2} defaultValue={1} />);
+      expect(wrapper.getInputValue()).toEqual('2');
+    });
   });
 
   describe(`required prop`, () => {


### PR DESCRIPTION
To fix  [antd#30873](https://github.com/ant-design/ant-design/issues/30873#issue-912165399). Sync-ed behaviour with  [`Input` component](https://github.com/ant-design/ant-design/blob/ad60e9544cbb8ef9d638e667b8d28cdfac157314/components/input/Input.tsx#L181)