### PR TITLE
fix(onChange): specify event may triggered with `null`

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -60,7 +60,7 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   decimalSeparator?: string;
 
   onInput?: (text: string) => void;
-  onChange?: (value: T) => void;
+  onChange?: (value: T | null) => void;
   onPressEnter?: React.KeyboardEventHandler<HTMLInputElement>;
 
   onStep?: (value: T, info: { offset: ValueType; type: 'up' | 'down' }) => void;


### PR DESCRIPTION
`onChange` is triggered with `null` sometimes, but type of `value` is just `ValueType` (`string | number`) for now.
However making this change is likely going to be a breaking change; it's more confusing `null` is given without any notice.

## references
* https://github.com/react-component/input-number/blob/7440f52f3305632eda5fc20e1302ddacc7ec50ac/src/InputNumber.tsx#L294
* #316
```js
...
expect(onChange).toHaveBeenCalledWith(null);
...
```