### PR TITLE
refactor: refactor with Baseinput

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/runtime": "^7.10.1",
     "@rc-component/mini-decimal": "^1.0.1",
     "classnames": "^2.2.5",
-    "rc-input": "~1.0.4",
+    "rc-input": "~1.1.0",
     "rc-util": "^5.28.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/runtime": "^7.10.1",
     "@rc-component/mini-decimal": "^1.0.1",
     "classnames": "^2.2.5",
-    "rc-input": "^1.0.4",
+    "rc-input": "~1.0.4",
     "rc-util": "^5.28.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/runtime": "^7.10.1",
     "@rc-component/mini-decimal": "^1.0.1",
     "classnames": "^2.2.5",
+    "rc-input": "^1.0.4",
     "rc-util": "^5.28.0"
   },
   "devDependencies": {

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -7,6 +7,7 @@ import getMiniDecimal, {
   ValueType,
 } from '@rc-component/mini-decimal';
 import classNames from 'classnames';
+import { BaseInput } from 'rc-input';
 import { useLayoutUpdateEffect } from 'rc-util/lib/hooks/useLayoutEffect';
 import { composeRef } from 'rc-util/lib/ref';
 import * as React from 'react';
@@ -43,7 +44,7 @@ const getDecimalIfValidate = (value: ValueType) => {
 export interface InputNumberProps<T extends ValueType = ValueType>
   extends Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
-    'value' | 'defaultValue' | 'onInput' | 'onChange'
+    'value' | 'defaultValue' | 'onInput' | 'onChange' | 'prefix'
   > {
   /** value will show as string */
   stringMode?: boolean;
@@ -59,6 +60,9 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   step?: ValueType;
   tabIndex?: number;
   controls?: boolean;
+  prefix?: React.ReactNode;
+  addonBefore?: React.ReactNode;
+  addonAfter?: React.ReactNode;
 
   // Customize handler node
   upHandler?: React.ReactNode;
@@ -86,7 +90,7 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   // size?: ISize;
 }
 
-const InputNumber = React.forwardRef(
+const InternalInputNumber = React.forwardRef(
   (props: InputNumberProps, ref: React.Ref<HTMLInputElement>) => {
     const {
       prefixCls = 'rc-input-number',
@@ -573,6 +577,26 @@ const InputNumber = React.forwardRef(
           />
         </div>
       </div>
+    );
+  },
+);
+
+const InputNumber = React.forwardRef(
+  (props: InputNumberProps, ref: React.Ref<HTMLInputElement>) => {
+    const { disabled, style, prefixCls, value, prefix, addonBefore, addonAfter, ...rest } = props;
+    return (
+      <BaseInput
+        inputElement={
+          <InternalInputNumber prefixCls={prefixCls} disabled={disabled} ref={ref} {...rest} />
+        }
+        prefixCls={prefixCls}
+        value={value}
+        disabled={disabled}
+        style={style}
+        prefix={prefix}
+        addonAfter={addonAfter}
+        addonBefore={addonBefore}
+      />
     );
   },
 ) as (<T extends ValueType = ValueType>(

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -15,6 +15,7 @@ import useCursor from './hooks/useCursor';
 import StepHandler from './StepHandler';
 import { getDecupleSteps } from './utils/numberUtil';
 
+import { InputFocusOptions, triggerFocus } from 'rc-input/lib/utils/commonUtils';
 import useFrame from './hooks/useFrame';
 
 /**
@@ -591,11 +592,26 @@ const InputNumber = React.forwardRef(
   (props: InputNumberProps, ref: React.Ref<HTMLInputElement>) => {
     const { disabled, style, prefixCls, value, prefix, addonBefore, addonAfter, classes, ...rest } =
       props;
+
+    const inputFocusRef = React.useRef<HTMLInputElement>(null);
+
+    const focus = (option?: InputFocusOptions) => {
+      if (inputFocusRef.current) {
+        triggerFocus(inputFocusRef.current, option);
+      }
+    };
+
     return (
       <BaseInput
         inputElement={
-          <InternalInputNumber prefixCls={prefixCls} disabled={disabled} ref={ref} {...rest} />
+          <InternalInputNumber
+            prefixCls={prefixCls}
+            disabled={disabled}
+            ref={composeRef(inputFocusRef, ref)}
+            {...rest}
+          />
         }
+        triggerFocus={focus}
         prefixCls={prefixCls}
         value={value}
         disabled={disabled}

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -63,6 +63,11 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   prefix?: React.ReactNode;
   addonBefore?: React.ReactNode;
   addonAfter?: React.ReactNode;
+  classes?: {
+    affixWrapper?: string;
+    group?: string;
+    wrapper?: string;
+  };
 
   // Customize handler node
   upHandler?: React.ReactNode;
@@ -583,7 +588,8 @@ const InternalInputNumber = React.forwardRef(
 
 const InputNumber = React.forwardRef(
   (props: InputNumberProps, ref: React.Ref<HTMLInputElement>) => {
-    const { disabled, style, prefixCls, value, prefix, addonBefore, addonAfter, ...rest } = props;
+    const { disabled, style, prefixCls, value, prefix, addonBefore, addonAfter, classes, ...rest } =
+      props;
     return (
       <BaseInput
         inputElement={
@@ -596,6 +602,7 @@ const InputNumber = React.forwardRef(
         prefix={prefix}
         addonAfter={addonAfter}
         addonBefore={addonBefore}
+        classes={classes}
       />
     );
   },

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -603,6 +603,12 @@ const InputNumber = React.forwardRef(
         addonAfter={addonAfter}
         addonBefore={addonBefore}
         classes={classes}
+        components={{
+          affixWrapper: 'div',
+          groupWrapper: 'div',
+          wrapper: 'div',
+          groupAddon: 'div',
+        }}
       />
     );
   },

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -6,7 +6,7 @@ import getMiniDecimal, {
   validateNumber,
   ValueType,
 } from '@rc-component/mini-decimal';
-import classNames from 'classnames';
+import clsx from 'classnames';
 import { BaseInput } from 'rc-input';
 import { useLayoutUpdateEffect } from 'rc-util/lib/hooks/useLayoutEffect';
 import { composeRef } from 'rc-util/lib/ref';
@@ -45,7 +45,7 @@ const getDecimalIfValidate = (value: ValueType) => {
 export interface InputNumberProps<T extends ValueType = ValueType>
   extends Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
-    'value' | 'defaultValue' | 'onInput' | 'onChange' | 'prefix'
+    'value' | 'defaultValue' | 'onInput' | 'onChange' | 'prefix' | 'suffix'
   > {
   /** value will show as string */
   stringMode?: boolean;
@@ -62,12 +62,19 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   tabIndex?: number;
   controls?: boolean;
   prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
   addonBefore?: React.ReactNode;
   addonAfter?: React.ReactNode;
   classes?: {
     affixWrapper?: string;
     group?: string;
     wrapper?: string;
+  };
+  classNames?: {
+    affixWrapper?: string;
+    group?: string;
+    wrapper?: string;
+    input?: string;
   };
 
   // Customize handler node
@@ -114,6 +121,7 @@ const InternalInputNumber = React.forwardRef(
       keyboard,
       controls = true,
 
+      classNames,
       stringMode,
 
       parser,
@@ -537,13 +545,18 @@ const InternalInputNumber = React.forwardRef(
     // ============================ Render ============================
     return (
       <div
-        className={classNames(prefixCls, className, {
-          [`${prefixCls}-focused`]: focus,
-          [`${prefixCls}-disabled`]: disabled,
-          [`${prefixCls}-readonly`]: readOnly,
-          [`${prefixCls}-not-a-number`]: decimalValue.isNaN(),
-          [`${prefixCls}-out-of-range`]: !decimalValue.isInvalidate() && !isInRange(decimalValue),
-        })}
+        className={clsx(
+          prefixCls,
+          className,
+          {
+            [`${prefixCls}-focused`]: focus,
+            [`${prefixCls}-disabled`]: disabled,
+            [`${prefixCls}-readonly`]: readOnly,
+            [`${prefixCls}-not-a-number`]: decimalValue.isNaN(),
+            [`${prefixCls}-out-of-range`]: !decimalValue.isInvalidate() && !isInRange(decimalValue),
+          },
+          classNames?.input,
+        )}
         style={style}
         onFocus={() => {
           setFocus(true);
@@ -589,8 +602,19 @@ const InternalInputNumber = React.forwardRef(
 
 const InputNumber = React.forwardRef(
   (props: InputNumberProps, ref: React.Ref<HTMLInputElement>) => {
-    const { disabled, style, prefixCls, value, prefix, addonBefore, addonAfter, classes, ...rest } =
-      props;
+    const {
+      disabled,
+      style,
+      prefixCls,
+      value,
+      prefix,
+      addonBefore,
+      addonAfter,
+      classes,
+      className,
+      classNames,
+      ...rest
+    } = props;
 
     const inputFocusRef = React.useRef<HTMLInputElement>(null);
 
@@ -606,10 +630,12 @@ const InputNumber = React.forwardRef(
           <InternalInputNumber
             prefixCls={prefixCls}
             disabled={disabled}
+            classNames={classNames}
             ref={composeRef(inputFocusRef, ref)}
             {...rest}
           />
         }
+        className={className}
         triggerFocus={focus}
         prefixCls={prefixCls}
         value={value}
@@ -619,6 +645,7 @@ const InputNumber = React.forwardRef(
         addonAfter={addonAfter}
         addonBefore={addonBefore}
         classes={classes}
+        classNames={classNames}
         components={{
           affixWrapper: 'div',
           groupWrapper: 'div',

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -45,7 +45,7 @@ const getDecimalIfValidate = (value: ValueType) => {
 export interface InputNumberProps<T extends ValueType = ValueType>
   extends Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
-    'value' | 'defaultValue' | 'onInput' | 'onChange' | 'prefix' | 'suffix'
+    'value' | 'defaultValue' | 'onInput' | 'onChange' | 'prefix'
   > {
   /** value will show as string */
   stringMode?: boolean;
@@ -62,7 +62,6 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   tabIndex?: number;
   controls?: boolean;
   prefix?: React.ReactNode;
-  suffix?: React.ReactNode;
   addonBefore?: React.ReactNode;
   addonAfter?: React.ReactNode;
   classes?: {

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -44,7 +44,7 @@ const getDecimalIfValidate = (value: ValueType) => {
 export interface InputNumberProps<T extends ValueType = ValueType>
   extends Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
-    'value' | 'defaultValue' | 'onInput' | 'onChange' | 'prefix'
+    'value' | 'defaultValue' | 'onInput' | 'onChange' | 'prefix' | 'suffix'
   > {
   /** value will show as string */
   stringMode?: boolean;
@@ -61,6 +61,7 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   tabIndex?: number;
   controls?: boolean;
   prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
   addonBefore?: React.ReactNode;
   addonAfter?: React.ReactNode;
   classes?: {

--- a/tests/__snapshots__/baseInput.test.tsx.snap
+++ b/tests/__snapshots__/baseInput.test.tsx.snap
@@ -1,0 +1,185 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`baseInput addon should render properly 1`] = `
+<div>
+  <div>
+    <span
+      class="rc-input-group-wrapper"
+    >
+      <span
+        class="rc-input-wrapper rc-input-group"
+      >
+        <span
+          class="rc-input-group-addon"
+        >
+          <span>
+            Addon Before
+          </span>
+        </span>
+        <div
+          class="rc-input"
+        >
+          <div
+            class="rc-input-handler-wrap"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="Increase Value"
+              class="rc-input-handler rc-input-handler-up"
+              role="button"
+              unselectable="on"
+            >
+              <span
+                class="rc-input-handler-up-inner"
+                unselectable="on"
+              />
+            </span>
+            <span
+              aria-disabled="false"
+              aria-label="Decrease Value"
+              class="rc-input-handler rc-input-handler-down"
+              role="button"
+              unselectable="on"
+            >
+              <span
+                class="rc-input-handler-down-inner"
+                unselectable="on"
+              />
+            </span>
+          </div>
+          <div
+            class="rc-input-input-wrap"
+          >
+            <input
+              autocomplete="off"
+              class="rc-input-input"
+              role="spinbutton"
+              step="1"
+              value=""
+            />
+          </div>
+        </div>
+      </span>
+    </span>
+    <br />
+    <br />
+    <span
+      class="rc-input-group-wrapper"
+    >
+      <span
+        class="rc-input-wrapper rc-input-group"
+      >
+        <div
+          class="rc-input"
+        >
+          <div
+            class="rc-input-handler-wrap"
+          >
+            <span
+              aria-disabled="false"
+              aria-label="Increase Value"
+              class="rc-input-handler rc-input-handler-up"
+              role="button"
+              unselectable="on"
+            >
+              <span
+                class="rc-input-handler-up-inner"
+                unselectable="on"
+              />
+            </span>
+            <span
+              aria-disabled="false"
+              aria-label="Decrease Value"
+              class="rc-input-handler rc-input-handler-down"
+              role="button"
+              unselectable="on"
+            >
+              <span
+                class="rc-input-handler-down-inner"
+                unselectable="on"
+              />
+            </span>
+          </div>
+          <div
+            class="rc-input-input-wrap"
+          >
+            <input
+              autocomplete="off"
+              class="rc-input-input"
+              role="spinbutton"
+              step="1"
+              value=""
+            />
+          </div>
+        </div>
+        <span
+          class="rc-input-group-addon"
+        >
+          <span>
+            Addon After
+          </span>
+        </span>
+      </span>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`baseInput prefix should render properly 1`] = `
+<div>
+  <span
+    class="rc-input-affix-wrapper"
+  >
+    <span
+      class="rc-input-prefix"
+    >
+      <span>
+        Prefix
+      </span>
+    </span>
+    <div
+      class="rc-input"
+    >
+      <div
+        class="rc-input-handler-wrap"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="rc-input-handler rc-input-handler-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            class="rc-input-handler-up-inner"
+            unselectable="on"
+          />
+        </span>
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="rc-input-handler rc-input-handler-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            class="rc-input-handler-down-inner"
+            unselectable="on"
+          />
+        </span>
+      </div>
+      <div
+        class="rc-input-input-wrap"
+      >
+        <input
+          autocomplete="off"
+          class="rc-input-input"
+          role="spinbutton"
+          step="1"
+          value=""
+        />
+      </div>
+    </div>
+  </span>
+</div>
+`;

--- a/tests/__snapshots__/baseInput.test.tsx.snap
+++ b/tests/__snapshots__/baseInput.test.tsx.snap
@@ -3,19 +3,19 @@
 exports[`baseInput addon should render properly 1`] = `
 <div>
   <div>
-    <span
+    <div
       class="rc-input-group-wrapper"
     >
-      <span
+      <div
         class="rc-input-wrapper rc-input-group"
       >
-        <span
+        <div
           class="rc-input-group-addon"
         >
           <span>
             Addon Before
           </span>
-        </span>
+        </div>
         <div
           class="rc-input"
         >
@@ -59,14 +59,14 @@ exports[`baseInput addon should render properly 1`] = `
             />
           </div>
         </div>
-      </span>
-    </span>
+      </div>
+    </div>
     <br />
     <br />
-    <span
+    <div
       class="rc-input-group-wrapper"
     >
-      <span
+      <div
         class="rc-input-wrapper rc-input-group"
       >
         <div
@@ -112,22 +112,22 @@ exports[`baseInput addon should render properly 1`] = `
             />
           </div>
         </div>
-        <span
+        <div
           class="rc-input-group-addon"
         >
           <span>
             Addon After
           </span>
-        </span>
-      </span>
-    </span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`baseInput prefix should render properly 1`] = `
 <div>
-  <span
+  <div
     class="rc-input-affix-wrapper"
   >
     <span
@@ -180,6 +180,6 @@ exports[`baseInput prefix should render properly 1`] = `
         />
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/tests/baseInput.test.tsx
+++ b/tests/baseInput.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import InputNumber from '../src';
+
+describe('baseInput', () => {
+  it('prefix should render properly', () => {
+    const prefix = <span>Prefix</span>;
+
+    const { container } = render(<InputNumber prefixCls="rc-input" prefix={prefix} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('addon should render properly', () => {
+    const addonBefore = <span>Addon Before</span>;
+    const addonAfter = <span>Addon After</span>;
+
+    const { container } = render(
+      <div>
+        <InputNumber prefixCls="rc-input" addonBefore={addonBefore} />
+        <br />
+        <br />
+        <InputNumber prefixCls="rc-input" addonAfter={addonAfter} />
+      </div>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
1. Rc-input-number 引入 BaseInput，这里参考 rc-input, rc-textarea, rc-mentions，把 antd 那里传过来的一些 props 又传到 BaseInput 里了，包括但不限于 addonBefore、addonAfter、prefix。
2. 之前 antd-design 中，addonBefore 等属性没有传到 rc-input-number 里管理，参考 input 做了下调整。
