### PR TITLE
type: export ValueType

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -18,6 +18,8 @@ import { getDecupleSteps } from './utils/numberUtil';
 import { InputFocusOptions, triggerFocus } from 'rc-input/lib/utils/commonUtils';
 import useFrame from './hooks/useFrame';
 
+export type { ValueType };
+
 /**
  * We support `stringMode` which need handle correct type when user call in onChange
  * format max or min value

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import InputNumber, { InputNumberProps } from './InputNumber';
+import type { InputNumberProps, ValueType } from './InputNumber';
+import InputNumber from './InputNumber';
 
-export type { InputNumberProps };
+export type { InputNumberProps, ValueType };
 
 export default InputNumber;


### PR DESCRIPTION
`ValueType` 在 antd 中也引用了，属于幽灵依赖，这里 export 出去让 antd 饮用 input-number 的类型