### PR TITLE
662d6ab: feat: when the `precision` prop is enabled, the decision of whether to round is determined by the `cutOnly` prop.

### DIFF
--- a/docs/demo/cutOnly.tsx
+++ b/docs/demo/cutOnly.tsx
@@ -1,0 +1,61 @@
+/* eslint no-console:0 */
+import React from 'react';
+import InputNumber from 'rc-input-number';
+import '../../assets/index.less';
+
+export default () => {
+  const [value, setValue] = React.useState<string | number>(null);
+  const [cutOnly, setCutOnly] = React.useState(true);
+  const [stringMode, setStringMode] = React.useState(false);
+  const [precision, setPrecision] = React.useState<string>('2');
+  const [decimalSeparator, setDecimalSeparator] = React.useState<string>(',');
+
+  return (
+    <div style={{ margin: 10 }}>
+      <InputNumber
+        aria-label="Number input example to demonstration custom precision value"
+        style={{ width: 100 }}
+        value={value}
+        onChange={(newValue) => {
+          console.log('onChange:', newValue);
+          setValue(newValue);
+        }}
+        precision={Number(precision)}
+        cutOnly={cutOnly}
+        decimalSeparator={decimalSeparator}
+      />
+      <div style={{ marginTop: 32 }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={cutOnly}
+            onChange={() => {
+              setCutOnly(!cutOnly);
+            }}
+          />
+          cutOnly
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={stringMode}
+            onChange={() => {
+              setStringMode(!stringMode);
+            }}
+          />
+          String Mode
+        </label>
+      </div>
+      <div>
+        <label>
+          precision:
+          <input type="number" onChange={(e) => setPrecision(e.target.value)} value={precision} />
+        </label>
+        <label>
+          decimalSeparator:
+          <input value={decimalSeparator} onChange={(e) => setDecimalSeparator(e.target.value)} />
+        </label>
+      </div>
+    </div>
+  );
+};

--- a/docs/example.md
+++ b/docs/example.md
@@ -37,6 +37,10 @@ nav:
 
 <code src="./demo/precision.tsx"></code>
 
+## cutOnly
+
+<code src="./demo/cutOnly.tsx"></code>
+
 ## simple-use-touch
 
 <code src="./demo/simple-use-touch.tsx"></code>

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -90,6 +90,8 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   formatter?: (value: T | undefined, info: { userTyping: boolean; input: string }) => string;
   /** Syntactic sugar of `formatter`. Config precision of display. */
   precision?: number;
+  /** Syntactic sugar of `formatter`. Config cutOnly of display. */
+  cutOnly?: boolean;
   /** Syntactic sugar of `formatter`. Config decimal separator of display. */
   decimalSeparator?: string;
 
@@ -131,6 +133,7 @@ const InternalInputNumber = React.forwardRef(
       parser,
       formatter,
       precision,
+      cutOnly = false,
       decimalSeparator,
 
       onChange,
@@ -341,7 +344,7 @@ const InternalInputNumber = React.forwardRef(
         const numStr = updateValue.toString();
         const mergedPrecision = getPrecision(numStr, userTyping);
         if (mergedPrecision >= 0) {
-          updateValue = getMiniDecimal(toFixed(numStr, '.', mergedPrecision));
+          updateValue = getMiniDecimal(toFixed(numStr, '.', mergedPrecision, cutOnly));
 
           // When to fixed. The value may out of min & max range.
           // 4 in [0, 3.8] => 3.8 => 4 (toFixed)

--- a/tests/cutOnly.test.tsx
+++ b/tests/cutOnly.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/react';
+import KeyCode from 'rc-util/lib/KeyCode';
+import InputNumber from '../src';
+
+describe('InputNumber.CutOnly', () => {
+  it('precision and cutOnly', async () => {
+    const Demo = () => {
+      const [value, setValue] = React.useState<string | number>(null);
+
+      return <InputNumber precision={1} cutOnly={true} value={value} onChange={setValue} />;
+    };
+
+    const { container } = render(<Demo />);
+    const input = container.querySelector('input');
+
+    // React use SyntheticEvent to handle `onBeforeInput`, let's mock this
+    fireEvent.keyPress(input, {
+      which: KeyCode.TWO,
+      keyCode: KeyCode.TWO,
+      char: '2',
+    });
+    fireEvent.keyPress(input, {
+      which: KeyCode.PERIOD,
+      keyCode: KeyCode.PERIOD,
+      char: '.',
+    });
+    fireEvent.keyPress(input, {
+      which: KeyCode.TWO,
+      keyCode: KeyCode.TWO,
+      char: '2',
+    });
+    fireEvent.keyPress(input, {
+      which: KeyCode.FIVE,
+      keyCode: KeyCode.FIVE,
+      char: '5',
+    });
+
+    fireEvent.change(input, {
+      target: {
+        value: '2.2',
+      },
+    });
+
+    expect(input.value).toEqual('2.2');
+  });
+});


### PR DESCRIPTION
### What problem does this feature solve?

当设置了precision属性，超过的小数位会四舍五入，在某些场景我们希望直接截断（例如💰方面）

### What does the proposed API look like?

`cutOnly?:boolean` 决定是否截断

备注： [ant-design/issues](https://github.com/ant-design/ant-design/issues/44279)