### PR TITLE
addEventListener('wheel', onWheel) add { passive: false }

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -524,7 +524,7 @@ const InternalInputNumber = React.forwardRef(
         // React onWheel is passive and we can't preventDefault() in it.
         // That's why we should subscribe with DOM listener
         // https://stackoverflow.com/questions/63663025/react-onwheel-handler-cant-preventdefault-because-its-a-passive-event-listenev
-        input.addEventListener('wheel', onWheel);
+        input.addEventListener('wheel', onWheel, { passive: false });
         return () => input.removeEventListener('wheel', onWheel);
       }
     }, [onInternalStep]);


### PR DESCRIPTION
In Chrome:

InputNumber.js:431 [Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952



![](https://raw.githubusercontent.com/puxiao/notes/master/imgs/input-number-pull-618.png)

