### PR TITLE
feat: add suffix prop

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -1,13 +1,12 @@
 @inputNumberPrefixCls: rc-input-number;
 
 .@{inputNumberPrefixCls} {
-  display: inline-block;
+  display: flex;
   height: 26px;
   margin: 0;
   padding: 0;
   font-size: 12px;
   line-height: 26px;
-  vertical-align: middle;
   border: 1px solid #d9d9d9;
   border-radius: 4px;
   transition: all 0.3s;
@@ -61,6 +60,7 @@
   }
 
   &-input-wrap {
+    flex: 1;
     height: 100%;
     overflow: hidden;
   }
@@ -81,7 +81,6 @@
   }
 
   &-handler-wrap {
-    float: right;
     width: 20px;
     height: 100%;
     border-left: 1px solid #d9d9d9;

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -106,7 +106,7 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   changeOnBlur?: boolean;
 }
 
-type InternalInputNumberProps = Omit<InputNumberProps, 'prefix' | 'suffix'> & {
+type InternalInputNumberProps = Omit<InputNumberProps, 'prefix'> & {
   domRef: React.Ref<HTMLDivElement>;
 };
 
@@ -119,6 +119,7 @@ const InternalInputNumber = React.forwardRef(
       min,
       max,
       step = 1,
+      suffix,
       defaultValue,
       value,
       disabled,
@@ -601,16 +602,6 @@ const InternalInputNumber = React.forwardRef(
         onCompositionEnd={onCompositionEnd}
         onBeforeInput={onBeforeInput}
       >
-        {controls && (
-          <StepHandler
-            prefixCls={prefixCls}
-            upNode={upHandler}
-            downNode={downHandler}
-            upDisabled={upDisabled}
-            downDisabled={downDisabled}
-            onStep={onInternalStep}
-          />
-        )}
         <div className={`${inputClassName}-wrap`}>
           <input
             autoComplete="off"
@@ -628,6 +619,17 @@ const InternalInputNumber = React.forwardRef(
             readOnly={readOnly}
           />
         </div>
+        {suffix && <div className={`${prefixCls}-suffix`}>{suffix}</div>}
+        {controls && (
+          <StepHandler
+            prefixCls={prefixCls}
+            upNode={upHandler}
+            downNode={downHandler}
+            upDisabled={upDisabled}
+            downDisabled={downDisabled}
+            onStep={onInternalStep}
+          />
+        )}
       </div>
     );
   },
@@ -640,7 +642,6 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
     prefixCls = 'rc-input-number',
     value,
     prefix,
-    suffix,
     addonBefore,
     addonAfter,
     className,
@@ -673,7 +674,6 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
       disabled={disabled}
       style={style}
       prefix={prefix}
-      suffix={suffix}
       addonAfter={addonAfter}
       addonBefore={addonBefore}
       classNames={classNames}

--- a/tests/props.test.tsx
+++ b/tests/props.test.tsx
@@ -63,6 +63,12 @@ describe('InputNumber.Props', () => {
 
   });
 
+  it('suffix', () => {
+    const { container } = render(<InputNumber suffix='¥' />);
+    const suffixEl = container.querySelector('.rc-input-number-suffix');
+    expect(suffixEl).toBeTruthy();
+  });
+
   describe('step', () => {
     it('basic', () => {
       const onChange = jest.fn();


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/49621
目前我的想法是：修改`suffix`的渲染位置，不在基于`BaseInput` 然后在做后面的优化（不知道可行不可行）
![chrome-capture-2024-7-1](https://github.com/react-component/input-number/assets/49827327/cfee1c6d-bfc9-4970-8c70-c09f14da85f6)
