### PR TITLE
chore: bump rc-input from 1.5.0 to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/runtime": "^7.10.1",
     "@rc-component/mini-decimal": "^1.0.1",
     "classnames": "^2.2.5",
-    "rc-input": "~1.5.0",
+    "rc-input": "~1.6.0",
     "rc-util": "^5.40.1"
   },
   "devDependencies": {


### PR DESCRIPTION
chore: bump rc-input from 1.5.0 to 1.6.0