### PR TITLE
feat: improve focus behavior

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -197,7 +197,6 @@ const inputRef = useRef<InputNumberRef>(null);
 useEffect(() => {
   inputRef.current.focus(); // the input will get focus
   inputRef.current.blur(); // the input will lose focus
-  console.log(inputRef.current.input); // The origin input element
 }, []);
 // ....
 <InputNumber ref={inputRef} />;
@@ -207,4 +206,3 @@ useEffect(() => {
 | -------- | --------------------------------------- | --------------------------------- |
 | focus    | `(options?: InputFocusOptions) => void` | The input get focus when called   |
 | blur     | `() => void`                            | The input loses focus when called |
-| input    | `HTMLInputElement \| null`              | The origin input element          |

--- a/docs/api.md
+++ b/docs/api.md
@@ -186,3 +186,25 @@ nav:
         </tr>
     </tbody>
 </table>
+
+## inputRef
+
+```tsx | pure
+import InputNumber, { InputNumberRef } from 'rc-input-number';
+
+const inputRef = useRef<InputNumberRef>(null);
+
+useEffect(() => {
+  inputRef.current.focus(); // the input will get focus
+  inputRef.current.blur(); // the input will lose focus
+  console.log(inputRef.current.input); // The origin input element
+}, []);
+// ....
+<InputNumber ref={inputRef} />;
+```
+
+| Property | Type                                    | Description                       |
+| -------- | --------------------------------------- | --------------------------------- |
+| focus    | `(options?: InputFocusOptions) => void` | The input get focus when called   |
+| blur     | `() => void`                            | The input loses focus when called |
+| input    | `HTMLInputElement \| null`              | The origin input element          |

--- a/docs/demo/focus.tsx
+++ b/docs/demo/focus.tsx
@@ -1,0 +1,28 @@
+/* eslint no-console:0 */
+import InputNumber, { InputNumberRef } from 'rc-input-number';
+import React from 'react';
+import '../../assets/index.less';
+
+export default () => {
+  const inputRef = React.useRef<InputNumberRef>(null);
+
+  return (
+    <div style={{ margin: 10 }}>
+      <InputNumber aria-label="focus example" value={10} style={{ width: 100 }} ref={inputRef} />
+      <div style={{ marginTop: 10 }}>
+        <button type="button" onClick={() => inputRef.current?.focus({ cursor: 'start' })}>
+          focus at start
+        </button>
+        <button type="button" onClick={() => inputRef.current?.focus({ cursor: 'end' })}>
+          focus at end
+        </button>
+        <button type="button" onClick={() => inputRef.current?.focus({ cursor: 'all' })}>
+          focus to select all
+        </button>
+        <button type="button" onClick={() => inputRef.current?.focus({ preventScroll: true })}>
+          focus prevent scroll
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/docs/example.md
+++ b/docs/example.md
@@ -45,4 +45,6 @@ nav:
 
 <code src="./demo/wheel.tsx"></code>
 
+## focus
 
+<code src="./demo/focus.tsx"></code>

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -32,6 +32,7 @@ export interface InputNumberRef extends HTMLInputElement {
     direction?: 'forward' | 'backward' | 'none',
   ) => void;
   select: () => void;
+  input: HTMLInputElement | null;
   nativeElement: HTMLElement;
 }
 

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -24,6 +24,14 @@ import useFrame from './hooks/useFrame';
 export type { ValueType };
 
 export interface InputNumberRef extends HTMLInputElement {
+  focus: (options?: InputFocusOptions) => void;
+  blur: () => void;
+  setSelectionRange: (
+    start: number,
+    end: number,
+    direction?: 'forward' | 'backward' | 'none',
+  ) => void;
+  select: () => void;
   nativeElement: HTMLElement;
 }
 
@@ -660,6 +668,21 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
 
   React.useImperativeHandle(ref, () =>
     proxyObject(inputFocusRef.current, {
+      focus,
+      blur: () => {
+        inputFocusRef.current?.blur();
+      },
+      setSelectionRange: (
+        start: number,
+        end: number,
+        direction?: 'forward' | 'backward' | 'none',
+      ) => {
+        inputFocusRef.current?.setSelectionRange(start, end, direction);
+      },
+      select: () => {
+        inputFocusRef.current?.select();
+      },
+      input: inputFocusRef.current,
       nativeElement: holderRef.current.nativeElement || inputNumberDomRef.current,
     }),
   );

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -26,13 +26,6 @@ export type { ValueType };
 export interface InputNumberRef extends HTMLInputElement {
   focus: (options?: InputFocusOptions) => void;
   blur: () => void;
-  setSelectionRange: (
-    start: number,
-    end: number,
-    direction?: 'forward' | 'backward' | 'none',
-  ) => void;
-  select: () => void;
-  input: HTMLInputElement | null;
   nativeElement: HTMLElement;
 }
 

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -663,20 +663,6 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
   React.useImperativeHandle(ref, () =>
     proxyObject(inputFocusRef.current, {
       focus,
-      blur: () => {
-        inputFocusRef.current?.blur();
-      },
-      setSelectionRange: (
-        start: number,
-        end: number,
-        direction?: 'forward' | 'backward' | 'none',
-      ) => {
-        inputFocusRef.current?.setSelectionRange(start, end, direction);
-      },
-      select: () => {
-        inputFocusRef.current?.select();
-      },
-      input: inputFocusRef.current,
       nativeElement: holderRef.current.nativeElement || inputNumberDomRef.current,
     }),
   );

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render } from '@testing-library/react';
+import InputNumber, { InputNumberRef } from 'rc-input-number';
+import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
+import React from 'react';
+
+const getInputRef = () => {
+  const ref = React.createRef<InputNumberRef>();
+  render(<InputNumber ref={ref} defaultValue={12345} />);
+  return ref;
+};
+
+describe('InputNumber.Focus', () => {
+  let inputSpy: ReturnType<typeof spyElementPrototypes>;
+  let focus: ReturnType<typeof jest.fn>;
+  let setSelectionRange: ReturnType<typeof jest.fn>;
+
+  beforeEach(() => {
+    focus = jest.fn();
+    setSelectionRange = jest.fn();
+    inputSpy = spyElementPrototypes(HTMLInputElement, {
+      focus,
+      setSelectionRange,
+    });
+  });
+
+  afterEach(() => {
+    inputSpy.mockRestore();
+  });
+
+  it('start', () => {
+    const input = getInputRef();
+    input.current?.focus({ cursor: 'start' });
+
+    expect(focus).toHaveBeenCalled();
+    expect(setSelectionRange).toHaveBeenCalledWith(expect.anything(), 0, 0);
+  });
+
+  it('end', () => {
+    const input = getInputRef();
+    input.current?.focus({ cursor: 'end' });
+
+    expect(focus).toHaveBeenCalled();
+    expect(setSelectionRange).toHaveBeenCalledWith(expect.anything(), 5, 5);
+  });
+
+  it('all', () => {
+    const input = getInputRef();
+    input.current?.focus({ cursor: 'all' });
+
+    expect(focus).toHaveBeenCalled();
+    expect(setSelectionRange).toHaveBeenCalledWith(expect.anything(), 0, 5);
+  });
+
+  it('disabled should reset focus', () => {
+    const { container, rerender } = render(<InputNumber prefixCls="rc-input-number" />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.focus(input);
+    expect(container.querySelector('.rc-input-number-focused')).toBeTruthy();
+
+    rerender(<InputNumber prefixCls="rc-input-number" disabled />);
+    fireEvent.blur(input);
+
+    expect(container.querySelector('.rc-input-number-focused')).toBeFalsy();
+  });
+});

--- a/tests/input.test.tsx
+++ b/tests/input.test.tsx
@@ -224,16 +224,6 @@ describe('InputNumber.Input', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('input should work', () => {
-    const ref = React.createRef<InputNumberRef>();
-    const { container } = render(<InputNumber ref={ref} />);
-    const inputEl = container.querySelector('input')!;
-    const rootEl = container.querySelector('.rc-input-number')!;
-
-    expect(ref.current?.input).toBe(inputEl);
-    expect(ref.current?.nativeElement).toBe(rootEl);
-  });
-
   describe('nativeElement', () => {
     it('basic', () => {
       const ref = React.createRef<InputNumberRef>();

--- a/tests/input.test.tsx
+++ b/tests/input.test.tsx
@@ -224,6 +224,16 @@ describe('InputNumber.Input', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('input should work', () => {
+    const ref = React.createRef<InputNumberRef>();
+    const { container } = render(<InputNumber ref={ref} />);
+    const inputEl = container.querySelector('input')!;
+    const rootEl = container.querySelector('.rc-input-number')!;
+
+    expect(ref.current?.input).toBe(inputEl);
+    expect(ref.current?.nativeElement).toBe(rootEl);
+  });
+
   describe('nativeElement', () => {
     it('basic', () => {
       const ref = React.createRef<InputNumberRef>();


### PR DESCRIPTION
- solve https://github.com/ant-design/ant-design/issues/51395 

rc-input-number的ref属性与rc-input对齐，支持了：
- inputRef.current.input
- inputRef.current.focus配置项对齐rc-input

另外：
- 补充单测
- 补充文档和demo
- 完善类型定义



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在API文档中新增了`InputNumber`组件的`inputRef`功能说明，包含`focus`和`blur`方法。
	- 新增示例组件，演示如何使用`InputNumber`组件进行程序化聚焦控制。
	- 在示例文档中添加了“focus”部分，引用了新的示例组件代码。

- **测试**
	- 新增了针对`InputNumber`组件聚焦和选择范围的单元测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->