### PR TITLE
feat: add a new parameter for onStep & update api-docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -80,7 +80,13 @@ nav:
           <td>readOnly</td>
           <td>Boolean</td>
           <td>false</td>
-          <td>Specifies that an InputNumber is read only </td>
+          <td>Specifies that an InputNumber is read only</td>
+        </tr>
+        <tr>
+          <td>changeOnWheel</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>Specifies that the value is set using the mouse wheel</td>
         </tr>
         <tr>
           <td>controls</td>
@@ -135,6 +141,12 @@ nav:
           <td>Function</td>
           <td></td>
           <td>Called when an element gets focus</td>
+        </tr>
+        <tr>
+          <td>onStep</td>
+          <td>(value: T, info: { offset: ValueType; type: 'up' | 'down', emitter: 'handler' | 'keydown' | 'wheel' }) => void</td>
+          <td></td>
+          <td>Called when the user clicks the arrows on the keyboard or interface and when the mouse wheel is spun.</td>
         </tr>
         <tr>
           <td>style</td>

--- a/docs/demo/on-step.tsx
+++ b/docs/demo/on-step.tsx
@@ -1,0 +1,46 @@
+/* eslint no-console:0 */
+import InputNumber from '@rc-component/input-number';
+import React, { useState } from 'react';
+import '../../assets/index.less';
+
+export default () => {
+  const [emitter, setEmitter] = useState('interface buttons (up)');
+  const [value, setValue] = React.useState<string | number>(0);
+
+  const onChange = (val: number) => {
+    console.warn('onChange:', val, typeof val);
+    setValue(val);
+  };
+
+  const onStep = (_: number, info: { offset: number; type: 'up' | 'down', emitter: 'handler' | 'keyboard' | 'wheel' }) => {
+    if (info.emitter === 'handler') {
+      setEmitter(`interface buttons (${info.type})`);
+    }
+
+    if (info.emitter === 'keyboard') {
+      setEmitter(`keyboard (${info.type})`);
+    }
+
+    if (info.emitter === 'wheel') {
+      setEmitter(`mouse wheel (${info.type})`);
+    }
+  };
+
+  return (
+    <div style={{ margin: 10 }}>
+      <h3>onStep callback</h3>
+      <InputNumber
+        aria-label="onStep callback example"
+        min={0}
+        max={10}
+        style={{ width: 100 }}
+        value={value}
+        changeOnWheel
+        onChange={onChange}
+        onStep={onStep}
+      />
+
+      <div style={{ marginTop: 10 }}>Triggered by: {emitter}</div>
+    </div>
+  );
+};

--- a/docs/example.md
+++ b/docs/example.md
@@ -41,6 +41,10 @@ nav:
 
 <code src="./demo/small-step.tsx"></code>
 
+## on-step
+
+<code src="./demo/on-step.tsx"></code>
+
 ## wheel
 
 <code src="./demo/wheel.tsx"></code>

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -99,7 +99,7 @@ export interface InputNumberProps<T extends ValueType = ValueType>
   onChange?: (value: T | null) => void;
   onPressEnter?: React.KeyboardEventHandler<HTMLInputElement>;
 
-  onStep?: (value: T, info: { offset: ValueType; type: 'up' | 'down' }) => void;
+  onStep?: (value: T, info: { offset: ValueType; type: 'up' | 'down', emitter: 'handler' | 'keyboard' | 'wheel' }) => void;
 
   /**
    * Trigger change onBlur event.
@@ -432,7 +432,7 @@ const InternalInputNumber = React.forwardRef(
     };
 
     // ============================= Step =============================
-    const onInternalStep = (up: boolean) => {
+    const onInternalStep = (up: boolean, emitter: 'handler' | 'keyboard' | 'wheel') => {
       // Ignore step since out of range
       if ((up && upDisabled) || (!up && downDisabled)) {
         return;
@@ -454,6 +454,7 @@ const InternalInputNumber = React.forwardRef(
       onStep?.(getDecimalValue(stringMode, updatedValue), {
         offset: shiftKeyRef.current ? getDecupleSteps(step) : step,
         type: up ? 'up' : 'down',
+        emitter,
       });
 
       inputRef.current?.focus();
@@ -511,7 +512,7 @@ const InternalInputNumber = React.forwardRef(
 
       // Do step
       if (!compositionRef.current && ['Up', 'ArrowUp', 'Down', 'ArrowDown'].includes(key)) {
-        onInternalStep(key === 'Up' || key === 'ArrowUp');
+        onInternalStep(key === 'Up' || key === 'ArrowUp', 'keyboard');
         event.preventDefault();
       }
     };
@@ -526,7 +527,7 @@ const InternalInputNumber = React.forwardRef(
         const onWheel = (event) => {
           // moving mouse wheel rises wheel event with deltaY < 0
           // scroll value grows from top to bottom, as screen Y coordinate
-          onInternalStep(event.deltaY < 0);
+          onInternalStep(event.deltaY < 0, 'wheel');
           event.preventDefault();
         };
         const input = inputRef.current;

--- a/src/StepHandler.tsx
+++ b/src/StepHandler.tsx
@@ -20,7 +20,7 @@ export interface StepHandlerProps {
   downNode?: React.ReactNode;
   upDisabled?: boolean;
   downDisabled?: boolean;
-  onStep: (up: boolean) => void;
+  onStep: (up: boolean, emitter: 'handler' | 'keyboard' | 'wheel') => void;
 }
 
 export default function StepHandler({
@@ -48,11 +48,11 @@ export default function StepHandler({
     e.preventDefault();
     onStopStep();
 
-    onStepRef.current(up);
+    onStepRef.current(up, 'handler');
 
     // Loop step for interval
     function loopStep() {
-      onStepRef.current(up);
+      onStepRef.current(up, 'handler');
 
       stepTimeoutRef.current = setTimeout(loopStep, STEP_INTERVAL);
     }

--- a/tests/click.test.tsx
+++ b/tests/click.test.tsx
@@ -23,6 +23,7 @@ describe('InputNumber.Click', () => {
     selector: string,
     changedValue: string | number,
     stepType: 'up' | 'down',
+    emitter: 'handler' | 'keyboard' | 'wheel',
   ) {
     it(name, () => {
       const onChange = jest.fn();
@@ -36,27 +37,27 @@ describe('InputNumber.Click', () => {
       fireEvent.click(container.querySelector(selector));
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(changedValue);
-      expect(onStep).toHaveBeenCalledWith(changedValue, { offset: 1, type: stepType });
+      expect(onStep).toHaveBeenCalledWith(changedValue, { offset: 1, type: stepType, emitter  });
       unmount();
     });
   }
 
   describe('basic work', () => {
-    testInputNumber('up button', { defaultValue: 10 }, '.rc-input-number-handler-up', 11, 'up');
+    testInputNumber('up button', { defaultValue: 10 }, '.rc-input-number-handler-up', 11, 'up', 'handler');
 
-    testInputNumber('down button', { value: 10 }, '.rc-input-number-handler-down', 9, 'down');
+    testInputNumber('down button', { value: 10 }, '.rc-input-number-handler-down', 9, 'down', 'handler');
   });
 
   describe('empty input', () => {
-    testInputNumber('up button', {}, '.rc-input-number-handler-up', 1, 'up');
+    testInputNumber('up button', {}, '.rc-input-number-handler-up', 1, 'up', 'handler');
 
-    testInputNumber('down button', {}, '.rc-input-number-handler-down', -1, 'down');
+    testInputNumber('down button', {}, '.rc-input-number-handler-down', -1, 'down', 'handler');
   });
 
   describe('empty with min & max', () => {
-    testInputNumber('up button', { min: 6, max: 10 }, '.rc-input-number-handler-up', 6, 'up');
+    testInputNumber('up button', { min: 6, max: 10 }, '.rc-input-number-handler-up', 6, 'up', 'handler');
 
-    testInputNumber('down button', { min: 6, max: 10 }, '.rc-input-number-handler-down', 6, 'down');
+    testInputNumber('down button', { min: 6, max: 10 }, '.rc-input-number-handler-down', 6, 'down', 'handler');
   });
 
   describe('null with min & max', () => {
@@ -66,6 +67,7 @@ describe('InputNumber.Click', () => {
       '.rc-input-number-handler-up',
       6,
       'up',
+      'handler',
     );
 
     testInputNumber(
@@ -74,6 +76,7 @@ describe('InputNumber.Click', () => {
       '.rc-input-number-handler-down',
       6,
       'down',
+      'handler',
     );
   });
 
@@ -183,7 +186,7 @@ describe('InputNumber.Click', () => {
     });
 
     expect(onChange).toHaveBeenCalledWith(1.1);
-    expect(onStep).toHaveBeenCalledWith(1.1, { offset: '0.1', type: 'down' });
+    expect(onStep).toHaveBeenCalledWith(1.1, { offset: '0.1', type: 'down', emitter: 'keyboard'  });
   });
 
   it('click up button with pressing shift key', () => {
@@ -201,6 +204,6 @@ describe('InputNumber.Click', () => {
       keyCode: KeyCode.UP,
     });
     expect(onChange).toHaveBeenCalledWith(1.3);
-    expect(onStep).toHaveBeenCalledWith(1.3, { offset: '0.1', type: 'up' });
+    expect(onStep).toHaveBeenCalledWith(1.3, { offset: '0.1', type: 'up', emitter: 'keyboard' });
   });
 });


### PR DESCRIPTION
My telecom company's products use this library in many parts of the application. I needed to separate the logic of entering a value into an input field from the arrows in the interface, from the arrows on the keyboard and from the mouse wheel.

The first thing I discovered was that there was no description of the onStep and changeOnWheel properties in the documentation. I have added these fixes to the document.

The second thing is that I was able to solve my problem without library edits, but the solution looks overhead. By examining the library source code, I found that in the second argument info of the onStep callback, you can add an emitter property: 'handler' | 'keyboard' | 'wheel' that will output what onStep was called with. For example: keyboard, mouse wheel, arrow buttons in the interface.

I think this function will be useful for more than just me, so I'm opening this pull-request. Have a nice day everyone!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 为数字输入组件新增了通过鼠标滚轮调整数值的功能，并增强了对键盘和鼠标事件的响应能力，能够区分不同的输入来源。
  
- **文档更新**
  - 更新了相关 API 文档，增加了新的属性说明和代码示例，帮助用户更好地理解和使用新增交互功能。
  
- **测试**
  - 调整了测试用例，以确保新交互特性的正确性和一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->