### PR TITLE
fix: number is duplicate when input number by keyboard's numeric keypad in Chrome

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -160,6 +160,7 @@ const InternalInputNumber = React.forwardRef(
     const userTypingRef = React.useRef(false);
     const compositionRef = React.useRef(false);
     const shiftKeyRef = React.useRef(false);
+    const imeCompositionRef = React.useRef(false);
 
     // ============================ Value =============================
     // Real value control
@@ -428,6 +429,9 @@ const InternalInputNumber = React.forwardRef(
 
     // >>> Input
     const onInternalInput: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+      if (imeCompositionRef.current && !compositionRef.current) {
+          return;
+      }
       collectInputValue(e.target.value);
     };
 
@@ -498,6 +502,12 @@ const InternalInputNumber = React.forwardRef(
 
       shiftKeyRef.current = shiftKey;
 
+      if (event.key === 'Process' || compositionRef.current) {
+        imeCompositionRef.current = true;
+      } else {
+        imeCompositionRef.current = false;
+      }
+
       if (key === 'Enter') {
         if (!compositionRef.current) {
           userTypingRef.current = false;
@@ -543,6 +553,8 @@ const InternalInputNumber = React.forwardRef(
 
     // >>> Focus & Blur
     const onBlur = () => {
+      imeCompositionRef.current = false;
+
       if (changeOnBlur) {
         flushInputValue(false);
       }

--- a/tests/formatter.test.tsx
+++ b/tests/formatter.test.tsx
@@ -63,6 +63,72 @@ describe('InputNumber.Formatter', () => {
     expect(onChange).toHaveBeenCalledWith(100);
   });
 
+  it('formatter on IME numeric keypad input', () => {
+    const { container } = render(
+      <InputNumber formatter={(value) => `${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')} />
+    );
+    const input = container.querySelector('input');
+    fireEvent.focus(input);
+    fireEvent.compositionStart(input);
+    fireEvent.keyDown(input, {
+      which: 229,
+      key: 'Process',
+      code: 'Numpad1',
+      keyCode: 229,
+      composed: true,
+    });
+    fireEvent.change(input, { target: { value: '1' } });
+    fireEvent.keyDown(input, {
+      which: 229,
+      key: 'Process',
+      code: 'Numpad2',
+      keyCode: 229,
+      composed: true,
+    });
+    fireEvent.change(input, { target: { value: '12' } });
+    fireEvent.keyDown(input, {
+      which: 229,
+      key: 'Process',
+      code: 'Numpad3',
+      keyCode: 229,
+      composed: true,
+    });
+    fireEvent.change(input, { target: { value: '123' } });
+    fireEvent.keyDown(input, {
+      which: 229,
+      key: 'Process',
+      code: 'Numpad4',
+      keyCode: 229,
+      composed: true,
+    });
+    fireEvent.change(input, { target: { value: '1234' } });
+    fireEvent.keyDown(input, {
+      which: 229,
+      key: 'Process',
+      code: 'Enter',
+      keyCode: 229,
+      composed: true,
+    });
+    fireEvent.compositionEnd(input);
+    fireEvent.blur(input);
+    expect(input.value).toEqual('1,234');
+
+    fireEvent.focus(input);
+    fireEvent.compositionStart(input);
+    fireEvent.keyDown(input, {
+      which: 229,
+      key: 'Process',
+      code: 'Numpad5',
+      keyCode: 229,
+      composed: true,
+    });
+    fireEvent.change(input, { target: { value: '12345' } });
+    fireEvent.compositionEnd(input);
+    fireEvent.change(input, { target: { value: '1234' } });
+    fireEvent.blur(input);
+    expect(input.value).toEqual('12,345');
+  });
+
   it('formatter and parser', () => {
     const onChange = jest.fn();
     const { container } = render(


### PR DESCRIPTION
chrome下日文输入法下有format时输入数字时数字重复。

复现地址：https://ant.design/components/input-number-cn#input-number-demo-formatter
chrome环境下，日文输入法，小键盘连续键入数字 `1234`， 不按Enter键，点击页面其他地方。输入框内的数字变成了 `$ 11,234`。

原因： 在onCompositionEnd 之后 还会有一次 onChange事件被触发。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 改进了输入处理机制，在使用输入法（IME）进行文字组合时防止了误收集输入，从而提升了多语言输入环境下的输入准确性和系统稳定性。

- **测试**
  - 新增测试用例，验证输入法（IME）数字键盘输入时格式化器的行为，确保格式化后的输入值正确反映数字输入。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->