### PR TITLE
fix: skip flushInputValue and onPressEnter during IME composition

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -540,10 +540,8 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
 
     shiftKeyRef.current = shiftKey;
 
-    if (key === 'Enter') {
-      if (!compositionRef.current) {
-        userTypingRef.current = false;
-      }
+    if (key === 'Enter' && !compositionRef.current) {
+      userTypingRef.current = false;
       flushInputValue(false);
       onPressEnter?.(event);
     }

--- a/tests/keyboard.test.tsx
+++ b/tests/keyboard.test.tsx
@@ -73,4 +73,57 @@ describe('InputNumber.Keyboard', () => {
     fireEvent.keyDown(input, { which: KeyCode.ENTER, key: 'Enter', keyCode: KeyCode.ENTER });
     expect(onChange).toHaveBeenCalledWith(2);
   });
+
+  describe('IME composition + Enter', () => {
+    it('should not trigger onPressEnter during composition', () => {
+      const onPressEnter = jest.fn();
+      const { container } = render(<InputNumber onPressEnter={onPressEnter} />);
+      const input = container.querySelector('input');
+
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: '123abc' } });
+      fireEvent.keyDown(input, {
+        which: KeyCode.ENTER,
+        key: 'Enter',
+        keyCode: KeyCode.ENTER,
+      });
+      expect(onPressEnter).not.toHaveBeenCalled();
+
+      fireEvent.compositionEnd(input, { data: '' });
+      fireEvent.change(input, { target: { value: '123' } });
+      fireEvent.keyDown(input, {
+        which: KeyCode.ENTER,
+        key: 'Enter',
+        keyCode: KeyCode.ENTER,
+      });
+      expect(onPressEnter).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not flush input value or fire onChange during composition', () => {
+      const onChange = jest.fn();
+      const { container } = render(<InputNumber precision={0} onChange={onChange} />);
+      const input = container.querySelector('input') as HTMLInputElement;
+
+      fireEvent.change(input, { target: { value: '12.34' } });
+      expect(onChange).toHaveBeenLastCalledWith(12.34);
+      onChange.mockClear();
+
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: '12.34abc' } });
+      expect(input.value).toBe('12.34abc');
+      expect(onChange).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(input, {
+        which: KeyCode.ENTER,
+        key: 'Enter',
+        keyCode: KeyCode.ENTER,
+      });
+      expect(input.value).toBe('12.34abc');
+      expect(onChange).not.toHaveBeenCalled();
+
+      fireEvent.compositionEnd(input, { data: '' });
+      expect(input.value).toBe('12.34abc');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
composition 未结束前不应执行 flushInputValue 和 onPressEnter，否则受控value会与输入框不同步。

- 问题：
<img width="1280" height="720" alt="2E13617B-C424-4717-8940-B77FB35DFA6B" src="https://github.com/user-attachments/assets/6d4b0cb3-60ac-4347-9141-b439cd79fb58" />

- 修改后：
<img width="1828" height="878" alt="2026-05-01 03 24 29" src="https://github.com/user-attachments/assets/17f45a10-9bd5-4c22-943b-6ab562291c82" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了输入法（IME）组合状态下的Enter键行为处理，确保Enter键在输入法活动期间被正确抑制。

* **Tests**
  * 新增键盘/输入法相关测试用例，验证Enter键和输入法组合状态的交互行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->