### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
   },
   "dependencies": {
     "@rc-component/mini-decimal": "^1.1.1",
-    "@rc-component/util": "^1.4.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@swc-node/jest": "^1.5.5",
     "@testing-library/jest-dom": "^6.1.5",

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -6,16 +6,14 @@ import getMiniDecimal, {
   validateNumber,
   ValueType,
 } from '@rc-component/mini-decimal';
-import { useLayoutUpdateEffect } from '@rc-component/util/lib/hooks/useLayoutEffect';
-import proxyObject from '@rc-component/util/lib/proxyObject';
+import type { InputFocusOptions } from '@rc-component/util';
+import { proxyObject, triggerFocus, useEvent, useLayoutUpdateEffect } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import useCursor from './hooks/useCursor';
 import StepHandler from './StepHandler';
 import { getDecupleSteps } from './utils/numberUtil';
 
-import { useEvent } from '@rc-component/util';
-import { triggerFocus, type InputFocusOptions } from '@rc-component/util/lib/Dom/focus';
 import useFrame from './hooks/useFrame';
 
 export type { ValueType };

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -6,8 +6,13 @@ import getMiniDecimal, {
   validateNumber,
   ValueType,
 } from '@rc-component/mini-decimal';
-import type { InputFocusOptions } from '@rc-component/util';
-import { proxyObject, triggerFocus, useEvent, useLayoutUpdateEffect } from '@rc-component/util';
+import {
+  type InputFocusOptions,
+  proxyObject,
+  triggerFocus,
+  useEvent,
+  useLayoutUpdateEffect,
+} from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import useCursor from './hooks/useCursor';

--- a/src/StepHandler.tsx
+++ b/src/StepHandler.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unknown-property */
-import raf from '@rc-component/util/lib/raf';
+import { raf } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 

--- a/src/hooks/useCursor.ts
+++ b/src/hooks/useCursor.ts
@@ -1,5 +1,5 @@
+import { warning } from '@rc-component/util';
 import { useRef } from 'react';
-import warning from '@rc-component/util/lib/warning';
 /**
  * Keep input cursor in the correct position if possible.
  * Is this necessary since we have `formatter` which may mass the content?

--- a/src/hooks/useFrame.ts
+++ b/src/hooks/useFrame.ts
@@ -1,5 +1,5 @@
-import { useRef, useEffect } from 'react';
-import raf from '@rc-component/util/lib/raf';
+import { raf } from '@rc-component/util';
+import { useEffect, useRef } from 'react';
 
 /**
  * Always trigger latest once when call multiple time

--- a/tests/click.test.tsx
+++ b/tests/click.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
 import InputNumber, { InputNumberProps } from '../src';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 
 jest.mock('@rc-component/mini-decimal/lib/supportUtil');
 const { supportBigInt } = require('@rc-component/mini-decimal/lib/supportUtil');
@@ -37,7 +37,7 @@ describe('InputNumber.Click', () => {
       fireEvent.click(container.querySelector(selector));
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(changedValue);
-      expect(onStep).toHaveBeenCalledWith(changedValue, { offset: 1, type: stepType, emitter  });
+      expect(onStep).toHaveBeenCalledWith(changedValue, { offset: 1, type: stepType, emitter });
       unmount();
     });
   }
@@ -186,7 +186,7 @@ describe('InputNumber.Click', () => {
     });
 
     expect(onChange).toHaveBeenCalledWith(1.1);
-    expect(onStep).toHaveBeenCalledWith(1.1, { offset: '0.1', type: 'down', emitter: 'keyboard'  });
+    expect(onStep).toHaveBeenCalledWith(1.1, { offset: '0.1', type: 'down', emitter: 'keyboard' });
   });
 
   it('click up button with pressing shift key', () => {

--- a/tests/cursor.test.tsx
+++ b/tests/cursor.test.tsx
@@ -1,11 +1,10 @@
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { render, fireEvent } from './util/wrapper';
 import InputNumber from '../src';
+import { fireEvent, render } from './util/wrapper';
 
 describe('InputNumber.Cursor', () => {
   function cursorInput(input: HTMLInputElement, pos?: number) {
-
     if (pos !== undefined) {
       input.setSelectionRange(pos, pos);
     }
@@ -17,12 +16,12 @@ describe('InputNumber.Cursor', () => {
     changeValue: string,
     cursorPos: number,
     which?: number,
-    key?: number|string,
+    key?: number | string,
   ) {
-    fireEvent.focus(input)
-    fireEvent.keyDown(input,{which,keyCode:which,key})
-    fireEvent.change(input,{ target: { value: changeValue, selectionStart: 1 }})
-    fireEvent.keyUp(input,{which,keyCode:which,key})
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { which, keyCode: which, key });
+    fireEvent.change(input, { target: { value: changeValue, selectionStart: 1 } });
+    fireEvent.keyUp(input, { which, keyCode: which, key });
   }
 
   // https://github.com/react-component/input-number/issues/235
@@ -42,12 +41,14 @@ describe('InputNumber.Cursor', () => {
   describe('pre-pend string', () => {
     it('quick typing', () => {
       // `$ ` => `9$ ` => `$ 9`
-      const { container } = render(<InputNumber defaultValue="$ " formatter={(val) => `$ ${val}`} />);
+      const { container } = render(
+        <InputNumber defaultValue="$ " formatter={(val) => `$ ${val}`} />,
+      );
       const input = container.querySelector('input');
-      fireEvent.focus(input)
+      fireEvent.focus(input);
       cursorInput(input, 0);
-      changeOnPos(input, '9$ ', 1, KeyCode.NUM_ONE,'1');
-      expect(cursorInput(input,3)).toEqual(3);
+      changeOnPos(input, '9$ ', 1, KeyCode.NUM_ONE, '1');
+      expect(cursorInput(input, 3)).toEqual(3);
     });
 
     describe('[LEGACY]', () => {
@@ -70,14 +71,14 @@ describe('InputNumber.Cursor', () => {
 
         const { container } = render(<Demo />);
         const input = container.querySelector('input');
-        fireEvent.focus(input)
+        fireEvent.focus(input);
         for (let i = 0; i < prependValue.length; i += 1) {
-          fireEvent.keyDown(input,{which: KeyCode.ONE,keyCode: KeyCode.ONE})
+          fireEvent.keyDown(input, { which: KeyCode.ONE, keyCode: KeyCode.ONE });
         }
 
         const finalValue = prependValue + initValue;
         cursorInput(input, prependValue.length);
-        fireEvent.change(input,{ target: { value: finalValue } });
+        fireEvent.change(input, { target: { value: finalValue } });
 
         return input;
       };
@@ -85,35 +86,40 @@ describe('InputNumber.Cursor', () => {
       it('should fix caret position on case 1', () => {
         // '$ 1'
         const input = setUpCursorTest('', '1');
-        expect(cursorInput(input,3)).toEqual(3);
+        expect(cursorInput(input, 3)).toEqual(3);
       });
 
       it('should fix caret position on case 2', () => {
         // '$ 111'
         const input = setUpCursorTest('', '111');
-        expect(cursorInput(input,5)).toEqual(5);
+        expect(cursorInput(input, 5)).toEqual(5);
       });
 
       it('should fix caret position on case 3', () => {
         // '$ 111'
         const input = setUpCursorTest('1', '11');
-        expect(cursorInput(input,4)).toEqual(4);
+        expect(cursorInput(input, 4)).toEqual(4);
       });
 
       it('should fix caret position on case 4', () => {
         // '$ 123,456'
         const input = setUpCursorTest('456', '123');
-        expect(cursorInput(input,6)).toEqual(6);
+        expect(cursorInput(input, 6)).toEqual(6);
       });
     });
   });
 
   describe('append string', () => {
     it('position caret before appended characters', () => {
-      const { container } = render(<InputNumber formatter={(value) => `${value}%`} parser={(value) => value.replace('%', '')} />);
+      const { container } = render(
+        <InputNumber
+          formatter={(value) => `${value}%`}
+          parser={(value) => value.replace('%', '')}
+        />,
+      );
       const input = container.querySelector('input');
       fireEvent.focus(input);
-      fireEvent.change(input,{ target: { value: '5' } });
+      fireEvent.change(input, { target: { value: '5' } });
       expect(cursorInput(input)).toEqual(1);
     });
   });

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -1,7 +1,7 @@
+import { spyElementPrototypes } from '@rc-component/util';
 import { fireEvent, render } from '@testing-library/react';
-import InputNumber, { InputNumberRef } from '../src';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 import React from 'react';
+import InputNumber, { InputNumberRef } from '../src';
 
 const getInputRef = () => {
   const ref = React.createRef<InputNumberRef>();

--- a/tests/formatter.test.tsx
+++ b/tests/formatter.test.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
 import InputNumber from '../src';
 import { fireEvent, render } from './util/wrapper';

--- a/tests/github.test.tsx
+++ b/tests/github.test.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
 import InputNumber from '../src';
 import { act, fireEvent, render, screen, waitFor } from './util/wrapper';

--- a/tests/input.test.tsx
+++ b/tests/input.test.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
 import InputNumber, { InputNumberProps, InputNumberRef } from '../src';
 import { fireEvent, render } from './util/wrapper';

--- a/tests/keyboard.test.tsx
+++ b/tests/keyboard.test.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import InputNumber from '../src';
 import { fireEvent, render } from './util/wrapper';
 

--- a/tests/precision.test.tsx
+++ b/tests/precision.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import { KeyCode } from '@rc-component/util';
 import '@testing-library/jest-dom';
-import { render, fireEvent } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
 import InputNumber from '../src';
 
 describe('InputNumber.Precision', () => {

--- a/tests/props.test.tsx
+++ b/tests/props.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import { KeyCode } from '@rc-component/util';
 import '@testing-library/jest-dom';
-import { render, fireEvent } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
 import type { ValueType } from '../src';
 import InputNumber from '../src';
 
@@ -410,7 +410,9 @@ describe('InputNumber.Props', () => {
   describe('mode props', () => {
     it('render spinner mode', () => {
       const { container } = render(<InputNumber value={1} mode="spinner" />);
-      expect(container.querySelector('.rc-input-number')).toHaveClass('rc-input-number-mode-spinner');
+      expect(container.querySelector('.rc-input-number')).toHaveClass(
+        'rc-input-number-mode-spinner',
+      );
     });
   });
 

--- a/tests/wheel.test.tsx
+++ b/tests/wheel.test.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import InputNumber from '../src';
 import { fireEvent, render } from './util/wrapper';
 
@@ -7,13 +7,15 @@ describe('InputNumber.Wheel', () => {
     const onChange = jest.fn();
     const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
     fireEvent.focus(container.firstChild);
-    fireEvent.wheel(container.querySelector('input'), {deltaY: -1});
+    fireEvent.wheel(container.querySelector('input'), { deltaY: -1 });
     expect(onChange).toHaveBeenCalledWith(1);
   });
 
   it('wheel up with pressing shift key', () => {
     const onChange = jest.fn();
-    const { container } = render(<InputNumber onChange={onChange} step={0.01} value={1.2} changeOnWheel />);
+    const { container } = render(
+      <InputNumber onChange={onChange} step={0.01} value={1.2} changeOnWheel />,
+    );
     fireEvent.focus(container.firstChild);
     fireEvent.keyDown(container.querySelector('input'), {
       which: KeyCode.SHIFT,
@@ -21,7 +23,7 @@ describe('InputNumber.Wheel', () => {
       keyCode: KeyCode.SHIFT,
       shiftKey: true,
     });
-    fireEvent.wheel(container.querySelector('input'), {deltaY: -1});
+    fireEvent.wheel(container.querySelector('input'), { deltaY: -1 });
     expect(onChange).toHaveBeenCalledWith(1.3);
   });
 
@@ -29,13 +31,15 @@ describe('InputNumber.Wheel', () => {
     const onChange = jest.fn();
     const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
     fireEvent.focus(container.firstChild);
-    fireEvent.wheel(container.querySelector('input'), {deltaY: 1});
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
     expect(onChange).toHaveBeenCalledWith(-1);
   });
 
   it('wheel down with pressing shift key', () => {
     const onChange = jest.fn();
-    const { container } = render(<InputNumber onChange={onChange} step={0.01} value={1.2} changeOnWheel />);
+    const { container } = render(
+      <InputNumber onChange={onChange} step={0.01} value={1.2} changeOnWheel />,
+    );
     fireEvent.focus(container.firstChild);
     fireEvent.keyDown(container.querySelector('input'), {
       which: KeyCode.SHIFT,
@@ -43,7 +47,7 @@ describe('InputNumber.Wheel', () => {
       keyCode: KeyCode.SHIFT,
       shiftKey: true,
     });
-    fireEvent.wheel(container.querySelector('input'), {deltaY: 1});
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
     expect(onChange).toHaveBeenCalledWith(1.1);
   });
 
@@ -52,22 +56,24 @@ describe('InputNumber.Wheel', () => {
     const { container, rerender } = render(<InputNumber onChange={onChange} />);
     fireEvent.focus(container.firstChild);
 
-    fireEvent.wheel(container.querySelector('input'), {deltaY: -1});
+    fireEvent.wheel(container.querySelector('input'), { deltaY: -1 });
     expect(onChange).not.toHaveBeenCalled();
 
-    fireEvent.wheel(container.querySelector('input'), {deltaY: 1});
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
     expect(onChange).not.toHaveBeenCalled();
 
     rerender(<InputNumber onChange={onChange} changeOnWheel />);
     fireEvent.focus(container.firstChild);
 
-    fireEvent.wheel(container.querySelector('input'), {deltaY: 1});
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
     expect(onChange).toHaveBeenCalledWith(-1);
   });
 
   it('wheel is limited to range', () => {
     const onChange = jest.fn();
-    const { container } = render(<InputNumber onChange={onChange} min={-3} max={3} changeOnWheel />);
+    const { container } = render(
+      <InputNumber onChange={onChange} min={-3} max={3} changeOnWheel />,
+    );
     fireEvent.focus(container.firstChild);
     fireEvent.keyDown(container.querySelector('input'), {
       which: KeyCode.SHIFT,
@@ -75,9 +81,9 @@ describe('InputNumber.Wheel', () => {
       keyCode: KeyCode.SHIFT,
       shiftKey: true,
     });
-    fireEvent.wheel(container.querySelector('input'), {deltaY: -1});
+    fireEvent.wheel(container.querySelector('input'), { deltaY: -1 });
     expect(onChange).toHaveBeenCalledWith(3);
-    fireEvent.wheel(container.querySelector('input'), {deltaY: 1});
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
     expect(onChange).toHaveBeenCalledWith(-3);
   });
 });


### PR DESCRIPTION
## 背景

antd 侧限制继续使用 rc 包的 `lib` / `es` 深路径导入，需要将 input-number 中对 rc 包内部路径的依赖迁移到包根入口。

## 调整内容

- 升级 `@rc-component/father-plugin`，使用插件统一拦截 rc 包 `lib` / `es` 深路径导入。
- 升级 `@rc-component/util`，将源码和测试中对 `KeyCode`、`raf`、`warning`、hooks、DOM 工具等内部路径的引用改为从 `@rc-component/util` 根入口导入。
- 保留 `click.test.tsx` 中原有的 `mini-decimal` mock 方式，仅替换 `KeyCode` 导入，避免扩大测试行为改动。
- 整理相关测试文件的导入顺序和格式。

## 验证

- `npm run lint`
- `npm test -- --runInBand`
- `npm run compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 升级运行时依赖 `@rc-component/util` 至最新版本，获得更好的性能和兼容性支持
  * 升级开发依赖 `@rc-component/father-plugin` 以支持新的构建工具链
  * 调整内部导入方式以适配依赖包的最新导出结构

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/input-number/pull/732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->