### PR TITLE
fix: improve wheel step precision

### DIFF
--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -607,7 +607,7 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
       // moving mouse wheel rises wheel event with deltaY < 0
       // scroll value grows from top to bottom, as screen Y coordinate
       onInternalStep(wheelDeltaRef.current < 0, 'wheel');
-      wheelDeltaRef.current = 0;
+      wheelDeltaRef.current -= Math.sign(wheelDeltaRef.current) * WHEEL_STEP_DISTANCE;
     }
   });
 

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -53,6 +53,22 @@ const getDecimalIfValidate = (value: ValueType) => {
   return decimal.isInvalidate() ? null : decimal;
 };
 
+const WHEEL_STEP_DISTANCE = 100;
+const WHEEL_LINE_HEIGHT = 40;
+const WHEEL_PAGE_HEIGHT = 800;
+const WHEEL_DELTA_RESET_INTERVAL = 200;
+
+const getWheelDeltaY = (event: WheelEvent) => {
+  switch (event.deltaMode) {
+    case 1:
+      return event.deltaY * WHEEL_LINE_HEIGHT;
+    case 2:
+      return event.deltaY * WHEEL_PAGE_HEIGHT;
+    default:
+      return event.deltaY;
+  }
+};
+
 type SemanticName = 'root' | 'actions' | 'input' | 'action' | 'prefix' | 'suffix';
 export interface InputNumberProps<T extends ValueType = ValueType>
   extends Omit<
@@ -189,6 +205,8 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
   const userTypingRef = React.useRef(false);
   const compositionRef = React.useRef(false);
   const shiftKeyRef = React.useRef(false);
+  const wheelDeltaRef = React.useRef(0);
+  const wheelTimestampRef = React.useRef(0);
 
   // ============================= Refs =============================
   const rootRef = React.useRef<HTMLDivElement>(null);
@@ -567,12 +585,36 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
     shiftKeyRef.current = false;
   };
 
+  const onInternalWheel = useEvent((event: WheelEvent) => {
+    const wheelDelta = getWheelDeltaY(event);
+    if (!wheelDelta) {
+      return;
+    }
+
+    const eventTimestamp = event.timeStamp || Date.now();
+    if (eventTimestamp - wheelTimestampRef.current > WHEEL_DELTA_RESET_INTERVAL) {
+      wheelDeltaRef.current = 0;
+    }
+    wheelTimestampRef.current = eventTimestamp;
+
+    if (wheelDeltaRef.current && Math.sign(wheelDeltaRef.current) !== Math.sign(wheelDelta)) {
+      wheelDeltaRef.current = 0;
+    }
+
+    wheelDeltaRef.current += wheelDelta;
+
+    if (Math.abs(wheelDeltaRef.current) >= WHEEL_STEP_DISTANCE) {
+      // moving mouse wheel rises wheel event with deltaY < 0
+      // scroll value grows from top to bottom, as screen Y coordinate
+      onInternalStep(wheelDeltaRef.current < 0, 'wheel');
+      wheelDeltaRef.current = 0;
+    }
+  });
+
   React.useEffect(() => {
     if (changeOnWheel && focus) {
-      const onWheel = (event) => {
-        // moving mouse wheel rises wheel event with deltaY < 0
-        // scroll value grows from top to bottom, as screen Y coordinate
-        onInternalStep(event.deltaY < 0, 'wheel');
+      const onWheel = (event: WheelEvent) => {
+        onInternalWheel(event);
         event.preventDefault();
       };
       const input = inputRef.current;
@@ -581,10 +623,14 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
         // That's why we should subscribe with DOM listener
         // https://stackoverflow.com/questions/63663025/react-onwheel-handler-cant-preventdefault-because-its-a-passive-event-listenev
         input.addEventListener('wheel', onWheel, { passive: false });
-        return () => input.removeEventListener('wheel', onWheel);
+        return () => {
+          input.removeEventListener('wheel', onWheel);
+          wheelDeltaRef.current = 0;
+          wheelTimestampRef.current = 0;
+        };
       }
     }
-  });
+  }, [changeOnWheel, focus, onInternalWheel]);
 
   // >>> Focus & Blur
   const onBlur = () => {
@@ -595,6 +641,8 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
     setFocus(false);
 
     userTypingRef.current = false;
+    wheelDeltaRef.current = 0;
+    wheelTimestampRef.current = 0;
   };
 
   // >>> Mouse events

--- a/tests/wheel.test.tsx
+++ b/tests/wheel.test.tsx
@@ -113,4 +113,38 @@ describe('InputNumber.Wheel', () => {
 
     expect(onChange).toHaveBeenCalledWith(1);
   });
+
+  it('supports page mode wheel delta', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
+
+    fireEvent.focus(container.firstChild);
+    fireEvent.wheel(container.querySelector('input'), { deltaMode: 2, deltaY: -1 });
+
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('ignores empty wheel delta', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
+
+    fireEvent.focus(container.firstChild);
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 0 });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('resets accumulated wheel delta when direction changes', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
+    const input = container.querySelector('input');
+
+    fireEvent.focus(container.firstChild);
+    fireEvent.wheel(input, { deltaY: -50 });
+    fireEvent.wheel(input, { deltaY: 50 });
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.wheel(input, { deltaY: 50 });
+    expect(onChange).toHaveBeenCalledWith(-1);
+  });
 });

--- a/tests/wheel.test.tsx
+++ b/tests/wheel.test.tsx
@@ -7,7 +7,7 @@ describe('InputNumber.Wheel', () => {
     const onChange = jest.fn();
     const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
     fireEvent.focus(container.firstChild);
-    fireEvent.wheel(container.querySelector('input'), { deltaY: -1 });
+    fireEvent.wheel(container.querySelector('input'), { deltaY: -100 });
     expect(onChange).toHaveBeenCalledWith(1);
   });
 
@@ -23,7 +23,7 @@ describe('InputNumber.Wheel', () => {
       keyCode: KeyCode.SHIFT,
       shiftKey: true,
     });
-    fireEvent.wheel(container.querySelector('input'), { deltaY: -1 });
+    fireEvent.wheel(container.querySelector('input'), { deltaY: -100 });
     expect(onChange).toHaveBeenCalledWith(1.3);
   });
 
@@ -31,7 +31,7 @@ describe('InputNumber.Wheel', () => {
     const onChange = jest.fn();
     const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
     fireEvent.focus(container.firstChild);
-    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 100 });
     expect(onChange).toHaveBeenCalledWith(-1);
   });
 
@@ -47,7 +47,7 @@ describe('InputNumber.Wheel', () => {
       keyCode: KeyCode.SHIFT,
       shiftKey: true,
     });
-    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 100 });
     expect(onChange).toHaveBeenCalledWith(1.1);
   });
 
@@ -56,16 +56,16 @@ describe('InputNumber.Wheel', () => {
     const { container, rerender } = render(<InputNumber onChange={onChange} />);
     fireEvent.focus(container.firstChild);
 
-    fireEvent.wheel(container.querySelector('input'), { deltaY: -1 });
+    fireEvent.wheel(container.querySelector('input'), { deltaY: -100 });
     expect(onChange).not.toHaveBeenCalled();
 
-    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 100 });
     expect(onChange).not.toHaveBeenCalled();
 
     rerender(<InputNumber onChange={onChange} changeOnWheel />);
     fireEvent.focus(container.firstChild);
 
-    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 100 });
     expect(onChange).toHaveBeenCalledWith(-1);
   });
 
@@ -81,9 +81,36 @@ describe('InputNumber.Wheel', () => {
       keyCode: KeyCode.SHIFT,
       shiftKey: true,
     });
-    fireEvent.wheel(container.querySelector('input'), { deltaY: -1 });
+    fireEvent.wheel(container.querySelector('input'), { deltaY: -100 });
     expect(onChange).toHaveBeenCalledWith(3);
-    fireEvent.wheel(container.querySelector('input'), { deltaY: 1 });
+    fireEvent.wheel(container.querySelector('input'), { deltaY: 100 });
     expect(onChange).toHaveBeenCalledWith(-3);
+  });
+
+  it('accumulates high precision wheel delta', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
+    const input = container.querySelector('input');
+
+    fireEvent.focus(container.firstChild);
+
+    for (let i = 0; i < 19; i += 1) {
+      fireEvent.wheel(input, { deltaY: -5 });
+    }
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.wheel(input, { deltaY: -5 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('supports line mode wheel delta', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
+
+    fireEvent.focus(container.firstChild);
+    fireEvent.wheel(container.querySelector('input'), { deltaMode: 1, deltaY: -3 });
+
+    expect(onChange).toHaveBeenCalledWith(1);
   });
 });

--- a/tests/wheel.test.tsx
+++ b/tests/wheel.test.tsx
@@ -104,6 +104,24 @@ describe('InputNumber.Wheel', () => {
     expect(onChange).toHaveBeenCalledWith(1);
   });
 
+  it('preserves remaining wheel delta after stepping', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);
+    const input = container.querySelector('input');
+
+    fireEvent.focus(container.firstChild);
+    fireEvent.wheel(input, { deltaY: -130 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(1);
+
+    fireEvent.wheel(input, { deltaY: -69 });
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    fireEvent.wheel(input, { deltaY: -1 });
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenLastCalledWith(2);
+  });
+
   it('supports line mode wheel delta', () => {
     const onChange = jest.fn();
     const { container } = render(<InputNumber onChange={onChange} changeOnWheel />);


### PR DESCRIPTION
## Summary

- Normalize wheel delta across pixel, line, and page modes.
- Accumulate wheel delta before triggering one InputNumber step.
- Reset accumulated delta when wheel gestures pause or reverse direction.
- Update wheel tests for threshold and high precision wheel behavior.

## Why

When `changeOnWheel` is enabled, each wheel event currently triggers one step. Low precision mouse wheels can emit many events for a small physical scroll, causing InputNumber values to jump too quickly.

Related to ant-design/ant-design#58328.

## Test

- `npm test -- tests/wheel.test.tsx --runInBand`
- `npm test -- --runInBand`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 优化 InputNumber 的鼠标滚轮交互：引入滚轮增量归一与累计阈值触发，提升小幅滚轮输入的一致性与灵敏度。
  * 扩展滚轮模式兼容性：统一处理像素/行/页等 delta 模式，跨浏览器表现更统一。
  * 交互稳健性增强：在失焦或方向切换时重置滚轮状态，避免历史滚动影响后续操作。

* **测试**
  * 增补并调整滚轮相关用例，覆盖高精度累积、步进后剩余增量、deltaMode 行/页、空增量忽略及方向切换重置等场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->