### PR TITLE
refactor: use renderable guards for input adornments

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@rc-component/mini-decimal": "^1.1.1",
-    "@rc-component/util": "^1.11.1",
+    "@rc-component/util": "^1.13.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/InputNumber.tsx
+++ b/src/InputNumber.tsx
@@ -8,6 +8,7 @@ import getMiniDecimal, {
 } from '@rc-component/mini-decimal';
 import {
   type InputFocusOptions,
+  isReactRenderable,
   proxyObject,
   triggerFocus,
   useEvent,
@@ -737,7 +738,7 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
     >
       {mode === 'spinner' && controls && downNode}
 
-      {prefix !== undefined && (
+      {isReactRenderable(prefix) && (
         <div className={clsx(`${prefixCls}-prefix`, classNames?.prefix)} style={styles?.prefix}>
           {prefix}
         </div>
@@ -760,7 +761,7 @@ const InputNumber = React.forwardRef<InputNumberRef, InputNumberProps>((props, r
         {...restProps}
       />
 
-      {suffix !== undefined && (
+      {isReactRenderable(suffix) && (
         <div className={clsx(`${prefixCls}-suffix`, classNames?.suffix)} style={styles?.suffix}>
           {suffix}
         </div>


### PR DESCRIPTION
## 说明

- 使用 `isReactRenderable` 统一判断 prefix 和 suffix 是否需要渲染
- 支持数字 `0` 等有效 React 内容，并避免为空内容创建装饰节点
- 将 `@rc-component/util` 的最低版本提升到首次提供该 helper 的 `^1.13.0`

## 验证

- `npm run tsc`
- `npm run lint`
- `npm test -- tests/props.test.tsx --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化数字输入框前缀和后缀的渲染判断，无法渲染的内容（如 `null`、`false`）将不会生成多余节点。
- **Chores**
  - 更新内部工具依赖版本，提升组件渲染兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->